### PR TITLE
feat(release): dual-publish woocommerce-rest-ts-api and woo-mcp-server

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,9 +38,24 @@ jobs:
         run: pnpm run lint
       - name: Test
         run: pnpm test
-      - name: Release (main branch only)
+      # Dual-package release on main:
+      # 1) semantic-release bumps/publishes the root library from conventional commits
+      # 2) publish-packages publishes any versions not yet on npm (library + woo-mcp-server)
+      - name: Release library (semantic-release, main only)
         if: github.ref == 'refs/heads/main'
         run: pnpm run semantic-release
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Publish monorepo packages (library + MCP if not already on npm)
+        if: github.ref == 'refs/heads/main'
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          # quality gates already ran above
+          SKIP_BUILD: "1"
+          SKIP_TESTS: "1"
+        run: |
+          chmod +x scripts/publish-packages.sh
+          bash scripts/publish-packages.sh

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -1,0 +1,99 @@
+# Dual-package npm release for the monorepo:
+#   1. woocommerce-rest-ts-api (root)
+#   2. woo-mcp-server (packages/mcp-server)
+#
+# Manual: Actions → "Release npm packages" → Run workflow
+# Optional dry-run without publishing.
+name: Release npm packages
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Pack only (do not publish)"
+        type: boolean
+        default: false
+      skip_library:
+        description: "Skip publishing woocommerce-rest-ts-api"
+        type: boolean
+        default: false
+      skip_mcp:
+        description: "Skip publishing woo-mcp-server"
+        type: boolean
+        default: false
+      skip_tests:
+        description: "Skip typecheck/lint/test (not recommended)"
+        type: boolean
+        default: false
+      create_tags:
+        description: "Create git tags after successful publish"
+        type: boolean
+        default: true
+
+permissions:
+  contents: write
+  id-token: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 11.5.0
+          run_install: false
+
+      - name: Use Node.js 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+          cache: pnpm
+          registry-url: https://registry.npmjs.org
+
+      - name: Install dependencies (frozen)
+        run: pnpm install --frozen-lockfile
+
+      - name: Publish packages
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          DRY_RUN: ${{ inputs.dry_run && '1' || '0' }}
+          SKIP_LIBRARY: ${{ inputs.skip_library && '1' || '0' }}
+          SKIP_MCP: ${{ inputs.skip_mcp && '1' || '0' }}
+          SKIP_TESTS: ${{ inputs.skip_tests && '1' || '0' }}
+          # build runs inside the script unless SKIP_BUILD
+          SKIP_BUILD: "0"
+        run: |
+          chmod +x scripts/publish-packages.sh
+          bash scripts/publish-packages.sh
+
+      - name: Create release tags
+        if: ${{ success() && inputs.create_tags && !inputs.dry_run }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          LIB_VER=$(node -p "require('./package.json').version")
+          MCP_VER=$(node -p "require('./packages/mcp-server/package.json').version")
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          tag_if_missing() {
+            local tag="$1"
+            if git rev-parse "$tag" >/dev/null 2>&1; then
+              echo "Tag $tag already exists — skip"
+            else
+              git tag -a "$tag" -m "Release $tag"
+              git push origin "$tag"
+              echo "Created tag $tag"
+            fi
+          }
+
+          tag_if_missing "v${LIB_VER}"
+          tag_if_missing "woo-mcp-server@${MCP_VER}"

--- a/README.md
+++ b/README.md
@@ -41,11 +41,22 @@ Source files: [`ui/presentation.html`](./ui/presentation.html) · [`ui/index.htm
 Talk to any WooCommerce store from **Claude Desktop**, custom agents, or any MCP client — without giving models a raw HTTP free-for-all.
 
 ```bash
-# monorepo
+# from npm (after publish)
+npm i -g woo-mcp-server
+# or monorepo dev
 pnpm install && pnpm run build
 export WC_URL=https://mystore.com WC_KEY=ck_… WC_SECRET=cs_…
-npx woo-mcp-server
+npx -y woo-mcp-server
 ```
+
+Published packages (separate):
+
+| Package | npm | Role |
+|---------|-----|------|
+| `woocommerce-rest-ts-api` | [npm](https://www.npmjs.com/package/woocommerce-rest-ts-api) | Typed REST client |
+| `woo-mcp-server` | [npm](https://www.npmjs.com/package/woo-mcp-server) | MCP STDIO server for AI agents |
+
+Release both: `pnpm run publish:packages` (or GitHub Action **Release npm packages**).
 
 **Highlights**
 

--- a/package.json
+++ b/package.json
@@ -32,12 +32,14 @@
     "format": "prettier --write \"**/*.ts\"",
     "lint": "eslint src/",
     "lint-and-fix": "eslint src/ --fix",
-    "prepublishOnly": "pnpm run format && pnpm run lint-and-fix",
+    "prepublishOnly": "pnpm run prepack",
     "clean": "rm -rf ./dist",
     "build:types": "pnpm exec tsc --emitDeclarationOnly --declaration",
     "build:cjs:esm": "esbuild ./src/index.ts --bundle --platform=node --target=es2022 --format=cjs --outfile=dist/index.js --sourcemap --external:axios --external:oauth-1.0a --external:url-parse && esbuild ./src/index.ts --bundle --platform=node --target=es2022 --format=esm --outfile=dist/index.mjs --sourcemap --external:axios --external:oauth-1.0a --external:url-parse",
     "prepack": "pnpm run clean && pnpm run build:cjs:esm && pnpm run build:types",
     "semantic-release": "semantic-release",
+    "publish:packages": "bash ./scripts/publish-packages.sh",
+    "publish:packages:dry": "DRY_RUN=1 bash ./scripts/publish-packages.sh",
     "commit": "cz"
   },
   "lint-staged": {

--- a/packages/mcp-server/LICENSE
+++ b/packages/mcp-server/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2019 WooCommerce
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -61,7 +61,19 @@ Or open the static files directly:
 
 ## Quick start
 
-### 1. Install & build (monorepo)
+### 1. Install
+
+**From npm (recommended for agents / Claude Desktop):**
+
+```bash
+npm install -g woo-mcp-server
+# or one-shot without a global install
+npx -y woo-mcp-server
+```
+
+This pulls [`woocommerce-rest-ts-api`](https://www.npmjs.com/package/woocommerce-rest-ts-api) `^8` automatically.
+
+**From this monorepo (development):**
 
 ```bash
 git clone https://github.com/Yuri-Lima/woocommerce-rest-api-ts-lib.git

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,10 +1,11 @@
 {
   "name": "woo-mcp-server",
   "version": "1.0.0",
-  "description": "Model Context Protocol (MCP) server for WooCommerce REST API — tools, resources, and prompts for AI agents",
+  "description": "Model Context Protocol (MCP) server for WooCommerce — 60+ tools, resources, and prompts for AI agents",
   "author": "Yuri Lima",
   "license": "MIT",
   "type": "module",
+  "private": false,
   "engines": {
     "node": ">=18.0.0"
   },
@@ -23,7 +24,32 @@
   },
   "files": [
     "dist",
-    "README.md"
+    "README.md",
+    "LICENSE"
+  ],
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Yuri-Lima/woocommerce-rest-api-ts-lib.git",
+    "directory": "packages/mcp-server"
+  },
+  "homepage": "https://github.com/Yuri-Lima/woocommerce-rest-api-ts-lib/tree/main/packages/mcp-server#readme",
+  "bugs": {
+    "url": "https://github.com/Yuri-Lima/woocommerce-rest-api-ts-lib/issues"
+  },
+  "keywords": [
+    "woocommerce",
+    "mcp",
+    "model-context-protocol",
+    "claude",
+    "ai-agent",
+    "gpt",
+    "rest-api",
+    "typescript",
+    "stdio"
   ],
   "scripts": {
     "build": "tsup",
@@ -31,11 +57,13 @@
     "test": "node --experimental-vm-modules ../../node_modules/jest/bin/jest.js --config jest.config.cjs --coverage",
     "test:unit": "node --experimental-vm-modules ../../node_modules/jest/bin/jest.js --config jest.config.cjs --testPathPattern=tests/tools",
     "start": "node dist/cli.js",
-    "clean": "rm -rf dist coverage"
+    "clean": "rm -rf dist coverage",
+    "prepublishOnly": "pnpm run build",
+    "prepack": "pnpm run build"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.12.1",
-    "woocommerce-rest-ts-api": "workspace:*",
+    "woocommerce-rest-ts-api": "workspace:^",
     "zod": "^3.24.2"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -121,7 +121,7 @@ importers:
         specifier: ^1.12.1
         version: 1.29.0(zod@3.25.76)
       woocommerce-rest-ts-api:
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../..
       zod:
         specifier: ^3.24.2

--- a/scripts/publish-packages.sh
+++ b/scripts/publish-packages.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# Publish both monorepo packages to npm as separate packages, in order:
+#   1) woocommerce-rest-ts-api  (root library)
+#   2) woo-mcp-server           (MCP server; depends on the library)
+#
+# pnpm rewrites workspace:^ → a real semver range in the published tarball.
+#
+# Usage:
+#   bash scripts/publish-packages.sh
+#   DRY_RUN=1 bash scripts/publish-packages.sh
+#   SKIP_LIBRARY=1 bash scripts/publish-packages.sh
+#   SKIP_MCP=1 bash scripts/publish-packages.sh
+#   SKIP_TESTS=1 bash scripts/publish-packages.sh   # CI that already tested
+#
+# Auth: set NODE_AUTH_TOKEN or NPM_TOKEN (npm automation token).
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${ROOT}"
+
+DRY_RUN="${DRY_RUN:-0}"
+SKIP_LIBRARY="${SKIP_LIBRARY:-0}"
+SKIP_MCP="${SKIP_MCP:-0}"
+SKIP_TESTS="${SKIP_TESTS:-0}"
+SKIP_BUILD="${SKIP_BUILD:-0}"
+
+LIBRARY_NAME="woocommerce-rest-ts-api"
+MCP_NAME="woo-mcp-server"
+
+log() { printf '\n\033[1;36m==>\033[0m %s\n' "$*"; }
+warn() { printf '\033[1;33m[warn]\033[0m %s\n' "$*"; }
+die() { printf '\033[1;31m[error]\033[0m %s\n' "$*" >&2; exit 1; }
+
+# Prefer NODE_AUTH_TOKEN (setup-node) then NPM_TOKEN
+if [[ -z "${NODE_AUTH_TOKEN:-}" && -n "${NPM_TOKEN:-}" ]]; then
+  export NODE_AUTH_TOKEN="${NPM_TOKEN}"
+fi
+
+if [[ -z "${NODE_AUTH_TOKEN:-}" && "${DRY_RUN}" != "1" ]]; then
+  die "NODE_AUTH_TOKEN or NPM_TOKEN is required to publish (or set DRY_RUN=1)."
+fi
+
+# Ephemeral auth — never write tokens into the repo .npmrc
+if [[ -n "${NODE_AUTH_TOKEN:-}" ]]; then
+  TMP_NPMRC="$(mktemp)"
+  cleanup_npmrc() { rm -f "${TMP_NPMRC}"; }
+  trap cleanup_npmrc EXIT
+  {
+    echo "registry=https://registry.npmjs.org/"
+    echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}"
+  } >"${TMP_NPMRC}"
+  export NPM_CONFIG_USERCONFIG="${TMP_NPMRC}"
+fi
+
+pkg_version() {
+  local dir="$1"
+  node -p "require('${dir}/package.json').version"
+}
+
+already_published() {
+  local name="$1"
+  local version="$2"
+  # returns 0 if version exists on registry
+  npm view "${name}@${version}" version --silent >/dev/null 2>&1
+}
+
+publish_one() {
+  local filter="$1"
+  local name="$2"
+  local dir="$3"
+  local version
+  version="$(pkg_version "${dir}")"
+
+  log "Package ${name}@${version}"
+
+  if already_published "${name}" "${version}"; then
+    warn "${name}@${version} already on npm — skipping publish."
+    return 0
+  fi
+
+  if [[ "${DRY_RUN}" == "1" ]]; then
+    log "DRY_RUN: packing ${filter}"
+    pnpm --filter "${filter}" exec npm pack --dry-run
+    # Show how workspace protocol would resolve for MCP
+    if [[ "${name}" == "${MCP_NAME}" ]]; then
+      local lib_ver
+      lib_ver="$(pkg_version "${ROOT}")"
+      log "Published dependency rewrite (pnpm): workspace:^ → ^${lib_ver}"
+    fi
+    return 0
+  fi
+
+  log "Publishing ${name}@${version} …"
+  # --no-git-checks: allow release from release workflow / clean CI tree
+  # publishConfig.access=public is set in each package.json
+  pnpm --filter "${filter}" publish --access public --no-git-checks
+
+  # Verify
+  local remote
+  remote="$(npm view "${name}@${version}" version 2>/dev/null || true)"
+  [[ "${remote}" == "${version}" ]] || die "Publish verification failed for ${name}@${version} (got: ${remote:-none})"
+  log "Verified ${name}@${version} on npm"
+}
+
+# ── Quality gates ──────────────────────────────────────────────────────────
+if [[ "${SKIP_BUILD}" != "1" ]]; then
+  log "Install (frozen)"
+  pnpm install --frozen-lockfile
+
+  log "Build library + MCP server"
+  pnpm run build
+fi
+
+if [[ "${SKIP_TESTS}" != "1" ]]; then
+  log "Typecheck"
+  pnpm run typecheck
+  log "Lint"
+  pnpm run lint
+  log "Test"
+  pnpm test
+fi
+
+# ── Publish order: library first, then MCP ────────────────────────────────
+if [[ "${SKIP_LIBRARY}" != "1" ]]; then
+  publish_one "${LIBRARY_NAME}" "${LIBRARY_NAME}" "${ROOT}"
+else
+  warn "Skipping library publish (SKIP_LIBRARY=1)"
+fi
+
+if [[ "${SKIP_MCP}" != "1" ]]; then
+  # MCP must see a resolvable library version on the registry when consumers install.
+  # We publish library first above; for dry-run we only warn.
+  lib_ver="$(pkg_version "${ROOT}")"
+  if [[ "${DRY_RUN}" != "1" ]] && ! already_published "${LIBRARY_NAME}" "${lib_ver}"; then
+    die "Library ${LIBRARY_NAME}@${lib_ver} is not on npm; publish it before ${MCP_NAME}."
+  fi
+  publish_one "${MCP_NAME}" "${MCP_NAME}" "${ROOT}/packages/mcp-server"
+else
+  warn "Skipping MCP publish (SKIP_MCP=1)"
+fi
+
+log "Done."
+printf '\nConsumers:\n'
+printf '  npm i %s@%s\n' "${LIBRARY_NAME}" "$(pkg_version "${ROOT}")"
+printf '  npm i -g %s@%s\n' "${MCP_NAME}" "$(pkg_version "${ROOT}/packages/mcp-server")"
+printf '  npx %s\n\n' "${MCP_NAME}"


### PR DESCRIPTION
## Summary
- Publish **two separate npm packages** from the monorepo:
  1. `woocommerce-rest-ts-api@8.0.0` (root library)
  2. `woo-mcp-server@1.0.0` (MCP server)
- MCP depends on `workspace:^` in-repo; **pnpm rewrites to `^8.0.0`** in the published tarball
- `scripts/publish-packages.sh` — ordered publish + skip-if-already-on-npm
- GitHub Action **Release npm packages** (`workflow_dispatch`)
- Main `Publish NPM CI` also attempts monorepo publish after semantic-release

## Test plan
- [x] `DRY_RUN=1` pack both packages locally
- [x] Verified packed `package.json` has `"woocommerce-rest-ts-api": "^8.0.0"`
- [ ] After merge: run **Release npm packages** workflow
- [ ] `npm view woocommerce-rest-ts-api version` → 8.0.0
- [ ] `npm view woo-mcp-server version` → 1.0.0