### PR TITLE
fix(release): classic npm auth for dual package publish

### DIFF
--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -32,7 +32,6 @@ on:
 
 permissions:
   contents: write
-  id-token: write
 
 jobs:
   release:
@@ -54,10 +53,24 @@ jobs:
         with:
           node-version: 22.x
           cache: pnpm
+          # Do not enable OIDC/provenance here — use classic NPM_TOKEN auth only.
           registry-url: https://registry.npmjs.org
+          always-auth: true
 
       - name: Install dependencies (frozen)
         run: pnpm install --frozen-lockfile
+
+      - name: Verify npm auth (whoami)
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          if [ -z "${NODE_AUTH_TOKEN}" ]; then
+            echo "NPM_TOKEN secret is empty" >&2
+            exit 1
+          fi
+          # setup-node writes .npmrc with ${NODE_AUTH_TOKEN}; export for npm
+          npm whoami
+          echo "Authenticated as $(npm whoami) — can publish"
 
       - name: Publish packages
         env:

--- a/scripts/publish-packages.sh
+++ b/scripts/publish-packages.sh
@@ -3,16 +3,12 @@
 #   1) woocommerce-rest-ts-api  (root library)
 #   2) woo-mcp-server           (MCP server; depends on the library)
 #
-# pnpm rewrites workspace:^ → a real semver range in the published tarball.
-#
 # Usage:
 #   bash scripts/publish-packages.sh
 #   DRY_RUN=1 bash scripts/publish-packages.sh
-#   SKIP_LIBRARY=1 bash scripts/publish-packages.sh
-#   SKIP_MCP=1 bash scripts/publish-packages.sh
-#   SKIP_TESTS=1 bash scripts/publish-packages.sh   # CI that already tested
+#   SKIP_LIBRARY=1 | SKIP_MCP=1 | SKIP_TESTS=1 | SKIP_BUILD=1
 #
-# Auth: set NODE_AUTH_TOKEN or NPM_TOKEN (npm automation token).
+# Auth: NODE_AUTH_TOKEN or NPM_TOKEN (npm automation token for owner yurimlima).
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -31,7 +27,6 @@ log() { printf '\n\033[1;36m==>\033[0m %s\n' "$*"; }
 warn() { printf '\033[1;33m[warn]\033[0m %s\n' "$*"; }
 die() { printf '\033[1;31m[error]\033[0m %s\n' "$*" >&2; exit 1; }
 
-# Prefer NODE_AUTH_TOKEN (setup-node) then NPM_TOKEN
 if [[ -z "${NODE_AUTH_TOKEN:-}" && -n "${NPM_TOKEN:-}" ]]; then
   export NODE_AUTH_TOKEN="${NPM_TOKEN}"
 fi
@@ -47,58 +42,123 @@ if [[ -n "${NODE_AUTH_TOKEN:-}" ]]; then
   trap cleanup_npmrc EXIT
   {
     echo "registry=https://registry.npmjs.org/"
+    echo "always-auth=true"
     echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}"
   } >"${TMP_NPMRC}"
   export NPM_CONFIG_USERCONFIG="${TMP_NPMRC}"
 fi
 
 pkg_version() {
-  local dir="$1"
-  node -p "require('${dir}/package.json').version"
+  node -p "require(require('path').resolve(process.argv[1], 'package.json')).version" "$1"
 }
 
 already_published() {
   local name="$1"
   local version="$2"
-  # returns 0 if version exists on registry
   npm view "${name}@${version}" version --silent >/dev/null 2>&1
 }
 
-publish_one() {
-  local filter="$1"
-  local name="$2"
-  local dir="$3"
+publish_library() {
   local version
-  version="$(pkg_version "${dir}")"
+  version="$(pkg_version "${ROOT}")"
+  log "Package ${LIBRARY_NAME}@${version}"
 
-  log "Package ${name}@${version}"
-
-  if already_published "${name}" "${version}"; then
-    warn "${name}@${version} already on npm — skipping publish."
+  if already_published "${LIBRARY_NAME}" "${version}"; then
+    warn "${LIBRARY_NAME}@${version} already on npm — skipping."
     return 0
   fi
 
   if [[ "${DRY_RUN}" == "1" ]]; then
-    log "DRY_RUN: packing ${filter}"
-    pnpm --filter "${filter}" exec npm pack --dry-run
-    # Show how workspace protocol would resolve for MCP
-    if [[ "${name}" == "${MCP_NAME}" ]]; then
-      local lib_ver
-      lib_ver="$(pkg_version "${ROOT}")"
-      log "Published dependency rewrite (pnpm): workspace:^ → ^${lib_ver}"
-    fi
+    log "DRY_RUN: npm pack (library)"
+    npm pack --dry-run --registry https://registry.npmjs.org/
     return 0
   fi
 
-  log "Publishing ${name}@${version} …"
-  # --no-git-checks: allow release from release workflow / clean CI tree
-  # publishConfig.access=public is set in each package.json
-  pnpm --filter "${filter}" publish --access public --no-git-checks
+  log "Publishing ${LIBRARY_NAME}@${version} …"
+  # prepublishOnly → prepack rebuilds dist
+  npm publish --access public --registry https://registry.npmjs.org/
 
-  # Verify
-  local remote
-  remote="$(npm view "${name}@${version}" version 2>/dev/null || true)"
-  [[ "${remote}" == "${version}" ]] || die "Publish verification failed for ${name}@${version} (got: ${remote:-none})"
+  verify_published "${LIBRARY_NAME}" "${version}"
+}
+
+publish_mcp() {
+  local version lib_ver
+  version="$(pkg_version "${ROOT}/packages/mcp-server")"
+  lib_ver="$(pkg_version "${ROOT}")"
+  log "Package ${MCP_NAME}@${version}"
+
+  if already_published "${MCP_NAME}" "${version}"; then
+    warn "${MCP_NAME}@${version} already on npm — skipping."
+    return 0
+  fi
+
+  if [[ "${DRY_RUN}" != "1" ]] && ! already_published "${LIBRARY_NAME}" "${lib_ver}"; then
+    die "Library ${LIBRARY_NAME}@${lib_ver} is not on npm; publish it before ${MCP_NAME}."
+  fi
+
+  # Ensure dist exists
+  if [[ ! -f "${ROOT}/packages/mcp-server/dist/cli.js" ]]; then
+    pnpm --filter "${MCP_NAME}" build
+  fi
+
+  if [[ "${DRY_RUN}" == "1" ]]; then
+    log "DRY_RUN: pnpm pack (mcp rewrites workspace:^ → ^${lib_ver})"
+    (cd packages/mcp-server && pnpm pack)
+    tar -xOf "packages/mcp-server/${MCP_NAME}-${version}.tgz" package/package.json | node -e \
+      "let s='';process.stdin.on('data',d=>s+=d);process.stdin.on('end',()=>{const p=JSON.parse(s);console.log('deps',p.dependencies);});"
+    rm -f "packages/mcp-server/${MCP_NAME}-${version}.tgz"
+    return 0
+  fi
+
+  # Stage temp publish tree: rewrite workspace: for plain npm publish
+  local tmp_dir
+  tmp_dir="$(mktemp -d)"
+  cp "${ROOT}/packages/mcp-server/package.json" "${tmp_dir}/"
+  cp "${ROOT}/packages/mcp-server/README.md" "${tmp_dir}/"
+  cp "${ROOT}/packages/mcp-server/LICENSE" "${tmp_dir}/"
+  cp -R "${ROOT}/packages/mcp-server/dist" "${tmp_dir}/"
+
+  node -e "
+const fs = require('fs');
+const path = require('path');
+const root = JSON.parse(fs.readFileSync(process.argv[1], 'utf8'));
+const pkgPath = process.argv[2];
+const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+delete pkg.scripts;
+const dep = pkg.dependencies && pkg.dependencies['woocommerce-rest-ts-api'];
+if (dep && String(dep).startsWith('workspace:')) {
+  let range = root.version;
+  if (dep === 'workspace:^' || dep.startsWith('workspace:^')) range = '^' + root.version;
+  else if (dep === 'workspace:~' || dep.startsWith('workspace:~')) range = '~' + root.version;
+  pkg.dependencies['woocommerce-rest-ts-api'] = range;
+  console.log('rewrote workspace dep →', range);
+}
+fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + '\n');
+" "${ROOT}/package.json" "${tmp_dir}/package.json"
+
+  log "Publishing ${MCP_NAME}@${version} …"
+  (cd "${tmp_dir}" && npm publish --access public --registry https://registry.npmjs.org/)
+  rm -rf "${tmp_dir}"
+
+  verify_published "${MCP_NAME}" "${version}"
+}
+
+verify_published() {
+  local name="$1"
+  local version="$2"
+  local remote=""
+  for _ in 1 2 3 4 5 6 7 8; do
+    remote="$(npm view "${name}@${version}" version 2>/dev/null || true)"
+    [[ "${remote}" == "${version}" ]] && break
+    sleep 2
+  done
+  if [[ "${remote}" != "${version}" ]]; then
+    die "Publish verification failed for ${name}@${version} (got: ${remote:-none}).
+If npm returned 404 on PUT, the NPM_TOKEN is usually expired or lacks publish rights
+for npm user 'yurimlima' (owner of ${LIBRARY_NAME}).
+Create a classic Automation token at https://www.npmjs.com/settings/~/tokens
+and set the GitHub secret NPM_TOKEN."
+  fi
   log "Verified ${name}@${version} on npm"
 }
 
@@ -120,21 +180,15 @@ if [[ "${SKIP_TESTS}" != "1" ]]; then
   pnpm test
 fi
 
-# ── Publish order: library first, then MCP ────────────────────────────────
+# ── Publish order ─────────────────────────────────────────────────────────
 if [[ "${SKIP_LIBRARY}" != "1" ]]; then
-  publish_one "${LIBRARY_NAME}" "${LIBRARY_NAME}" "${ROOT}"
+  publish_library
 else
   warn "Skipping library publish (SKIP_LIBRARY=1)"
 fi
 
 if [[ "${SKIP_MCP}" != "1" ]]; then
-  # MCP must see a resolvable library version on the registry when consumers install.
-  # We publish library first above; for dry-run we only warn.
-  lib_ver="$(pkg_version "${ROOT}")"
-  if [[ "${DRY_RUN}" != "1" ]] && ! already_published "${LIBRARY_NAME}" "${lib_ver}"; then
-    die "Library ${LIBRARY_NAME}@${lib_ver} is not on npm; publish it before ${MCP_NAME}."
-  fi
-  publish_one "${MCP_NAME}" "${MCP_NAME}" "${ROOT}/packages/mcp-server"
+  publish_mcp
 else
   warn "Skipping MCP publish (SKIP_MCP=1)"
 fi
@@ -143,4 +197,4 @@ log "Done."
 printf '\nConsumers:\n'
 printf '  npm i %s@%s\n' "${LIBRARY_NAME}" "$(pkg_version "${ROOT}")"
 printf '  npm i -g %s@%s\n' "${MCP_NAME}" "$(pkg_version "${ROOT}/packages/mcp-server")"
-printf '  npx %s\n\n' "${MCP_NAME}"
+printf '  npx -y %s\n\n' "${MCP_NAME}"


### PR DESCRIPTION
Fixes publish 404 caused by failed OIDC / token auth. Uses npm publish + NPM_TOKEN whoami gate.