### PR TITLE
chore(ci): enable free-tier CodeRabbit PR reviews

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,234 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+#
+# CodeRabbit free-tier PR reviews for this public monorepo.
+# One-time install (repo owner): https://app.coderabbit.ai/login
+# Docs: https://docs.coderabbit.ai/getting-started/quickstart
+# Config reference: https://docs.coderabbit.ai/reference/configuration
+
+language: en-US
+enable_free_tier: true
+tone_instructions: >
+  Be constructive and concise. Prefer actionable fixes over style nits.
+  Call out security, auth, and breaking API changes first.
+
+reviews:
+  profile: chill
+  request_changes_workflow: false
+  high_level_summary: true
+  high_level_summary_instructions: >
+    Summarize user-facing impact for both packages when relevant:
+    woocommerce-rest-ts-api (library) and woo-mcp-server (MCP package).
+    Call out breaking changes, security, and publish/release risk.
+  review_status: true
+  commit_status: true
+  collapse_walkthrough: true
+  changed_files_summary: true
+  sequence_diagrams: false
+  estimate_code_review_effort: true
+  assess_linked_issues: true
+  related_issues: true
+  related_prs: true
+  suggested_labels: true
+  auto_apply_labels: false
+  suggested_reviewers: true
+  auto_assign_reviewers: false
+  poem: false
+  in_progress_fortune: false
+  enable_prompt_for_ai_agents: true
+  abort_on_close: true
+
+  path_filters:
+    - "!**/node_modules/**"
+    - "!**/dist/**"
+    - "!**/coverage/**"
+    - "!**/*.min.js"
+    - "!**/*.map"
+    - "!pnpm-lock.yaml"
+    - "!package-lock.json"
+    - "!**/.DS_Store"
+    - "!ui/preview.gif"
+    - "!**/*.png"
+    - "!**/*.jpg"
+    - "!**/*.jpeg"
+    - "!**/*.webp"
+
+  path_instructions:
+    - path: "src/**"
+      instructions: |
+        TypeScript WooCommerce REST client library (published as woocommerce-rest-ts-api).
+        Focus on:
+        - Auth (OAuth 1.0a / basic), request signing, and credential handling — never log secrets
+        - HTTP client correctness, retries, throttling, error mapping
+        - Public API surface stability and TypeScript types exported to consumers
+        - Breaking changes vs CHANGELOG / MIGRATION notes
+        Prefer precise, minimal suggestions that preserve compatibility.
+
+    - path: "packages/mcp-server/**"
+      instructions: |
+        Model Context Protocol server (published as woo-mcp-server).
+        Focus on:
+        - Tool/resource/prompt contracts and input validation
+        - Safe handling of store URL and consumer keys/secrets (env only, no hardcoding)
+        - Dependency on woocommerce-rest-ts-api and monorepo/workspace publish coupling
+        - Stdio MCP server behavior and error messages useful to AI agents
+        Flag any path that could leak credentials into tool results or logs.
+
+    - path: "**/*.{test,spec}.{ts,tsx,js,cjs,mjs}"
+      instructions: |
+        Prefer meaningful assertions over brittle implementation details.
+        For nock/HTTP mocks, watch interceptor isolation and order across files.
+        Integration/live-store tests should skip cleanly without credentials.
+
+    - path: "packages/mcp-server/tests/**"
+      instructions: |
+        MCP package tests. Ensure tools are covered for happy path and validation failures.
+        Live-store tests must not require secrets in CI by default.
+
+    - path: "ui/**"
+      instructions: |
+        Demo UI and presentation assets. Flag XSS from unsanitized HTML, broken relative paths,
+        and accidental credential fields posted to third parties. Skip pure visual polish nits.
+
+    - path: ".github/workflows/**"
+      instructions: |
+        GitHub Actions. Check for secret leakage, overly broad permissions, unpinned actions
+        where risk is high, and publish/release steps that could publish wrong packages or
+        versions. Dual-publish order: library first, then woo-mcp-server.
+
+    - path: "scripts/**"
+      instructions: |
+        Release and local tooling scripts. Verify npm publish safety, token usage via env/secrets
+        only, and that workspace versions are rewritten correctly for the registry.
+
+    - path: "docs/**"
+      instructions: |
+        Documentation accuracy for install, publish, and MCP setup. Flag outdated package names
+        or version instructions.
+
+  labeling_instructions:
+    - label: library
+      instructions: Apply when changes touch src/ or root package.json for woocommerce-rest-ts-api.
+    - label: mcp
+      instructions: Apply when changes touch packages/mcp-server/**.
+    - label: ci
+      instructions: Apply when changes touch .github/workflows/** or Dependabot/Renovate config.
+    - label: docs
+      instructions: Apply when changes are primarily markdown under docs/ or README.
+    - label: security
+      instructions: Apply when changes affect auth, tokens, secrets handling, or dependency CVEs.
+
+  auto_review:
+    enabled: true
+    auto_incremental_review: true
+    auto_pause_after_reviewed_commits: 5
+    drafts: false
+    base_branches:
+      - main
+      - master
+      - "release/.*"
+      - "docs/.*"
+      - "fix/.*"
+      - "feat/.*"
+      - "chore/.*"
+    ignore_title_keywords:
+      - WIP
+      - "DO NOT MERGE"
+      - "[skip review]"
+      - "[skip cr]"
+    ignore_usernames:
+      - dependabot[bot]
+      - dependabot
+      - renovate[bot]
+      - renovate-bot
+      - github-actions[bot]
+
+  finishing_touches:
+    docstrings:
+      enabled: true
+    unit_tests:
+      enabled: true
+    simplify:
+      enabled: false
+
+  pre_merge_checks:
+    docstrings:
+      mode: "off"
+    title:
+      mode: warning
+      requirements: >
+        Prefer conventional-style titles (feat|fix|docs|chore|ci|refactor|test|security)
+        with a short scope when useful, e.g. "feat(mcp): add order tools".
+    description:
+      mode: warning
+    issue_assessment:
+      mode: "off"
+
+  # Static analysis tools that feed extra context into free-tier reviews.
+  tools:
+    eslint:
+      enabled: true
+    shellcheck:
+      enabled: true
+    gitleaks:
+      enabled: true
+    markdownlint:
+      enabled: true
+    github-checks:
+      enabled: true
+      timeout_ms: 300000
+    actionlint:
+      enabled: true
+    yamllint:
+      enabled: true
+    hadolint:
+      enabled: true
+    checkov:
+      enabled: true
+    checkmake:
+      enabled: true
+    dotenvLint:
+      enabled: true
+    semgrep:
+      enabled: true
+    ast-grep:
+      essential_rules: true
+    # Not used in this monorepo — keep off to reduce noise.
+    biome:
+      enabled: false
+    ruff:
+      enabled: false
+    languagetool:
+      enabled: false
+    shopifyThemeCheck:
+      enabled: false
+    circleci:
+      enabled: false
+
+chat:
+  auto_reply: true
+  art: false
+
+knowledge_base:
+  opt_out: false
+  web_search:
+    enabled: true
+  learnings:
+    scope: auto
+  issues:
+    scope: auto
+  pull_requests:
+    scope: auto
+  jira:
+    usage: auto
+  linear:
+    usage: auto
+  code_guidelines:
+    enabled: true
+    filePatterns:
+      - "**/.cursorrules"
+      - "**/.cursor/rules/**"
+      - "**/AGENTS.md"
+      - "**/CLAUDE.md"
+      - "**/SECURITY.md"
+      - "**/docs/CODERABBIT.md"
+      - "**/docs/PUBLISHING.md"

--- a/README.md
+++ b/README.md
@@ -539,7 +539,11 @@ If you're upgrading from an earlier version, note these changes:
 
 ## 🤝 Contributing
 
-We welcome contributions! Please see our [Contributing Guide](CONTRIBUTING.md) for details.
+We welcome contributions via pull requests.
+
+- **AI PR reviews (free):** open a non-draft PR and [CodeRabbit](https://coderabbit.ai) reviews it automatically on the free public-repo tier. Setup and commands: [docs/CODERABBIT.md](docs/CODERABBIT.md). Config: [`.coderabbit.yaml`](.coderabbit.yaml).
+- **Publishing:** [docs/PUBLISHING.md](docs/PUBLISHING.md)
+- **Security:** [SECURITY.md](SECURITY.md)
 
 ## 📄 License
 

--- a/docs/CODERABBIT.md
+++ b/docs/CODERABBIT.md
@@ -1,0 +1,87 @@
+# CodeRabbit free PR reviews
+
+This repository uses **[CodeRabbit](https://coderabbit.ai)** on the **free tier** for automatic AI code reviews on pull requests. Public GitHub repositories are eligible; no paid plan is required for basic PR reviews.
+
+Configuration lives in the repo root: [`.coderabbit.yaml`](../.coderabbit.yaml).
+
+## One-time setup (repo owner)
+
+CodeRabbit needs the GitHub App installed on this repository. Config alone is not enough.
+
+1. Open **[https://app.coderabbit.ai/login](https://app.coderabbit.ai/login)** and sign in with GitHub.
+2. **Add repositories** → select **`Yuri-Lima/woocommerce-rest-api-ts-lib`** (or install for all public repos you own).
+3. Approve the GitHub App permissions when prompted.
+4. Confirm the repo appears under [repository settings](https://app.coderabbit.ai/settings/repositories).
+
+Official quickstart: [CodeRabbit Quickstart](https://docs.coderabbit.ai/getting-started/quickstart).
+
+## What happens on each PR
+
+When the App is installed and a non-draft PR is opened (or updated):
+
+1. CodeRabbit posts a **walkthrough** summary on the PR.
+2. It leaves **inline comments** on issues it finds (security, bugs, API risk, etc.).
+3. Optional tools (ESLint, ShellCheck, Gitleaks, actionlint, …) add extra signal when relevant.
+4. Pushing new commits triggers an **incremental** re-review (with auto-pause after several reviewed commits to avoid noise).
+
+Reviews are **skipped** when:
+
+| Condition | Why |
+|-----------|-----|
+| Draft PR | `reviews.auto_review.drafts: false` |
+| Title contains `WIP`, `DO NOT MERGE`, `[skip review]`, or `[skip cr]` | Title keyword ignore list |
+| Author is Dependabot / Renovate / `github-actions[bot]` | Bot noise reduction |
+| PR base is not a configured branch pattern | See `base_branches` in YAML |
+
+## Useful PR comments
+
+Anyone with write access (or as allowed by chat settings) can comment:
+
+| Comment | Effect |
+|---------|--------|
+| `@coderabbitai review` | Request / re-run a full review |
+| `@coderabbitai summary` | Refresh the high-level summary (also a PR description placeholder) |
+| `@coderabbitai configuration` | Dump the **resolved** config (YAML + sources) |
+| `@coderabbitai resolve` | Resolve review threads CodeRabbit opened (when supported) |
+| `@coderabbitai generate docstrings` | Finishing touch: docstring PR |
+| `@coderabbitai generate unit tests` | Finishing touch: unit-test suggestions / PR |
+
+More commands: [CodeRabbit chat / commands](https://docs.coderabbit.ai/overview/pull-request-review).
+
+## Monorepo review focus
+
+Path-specific guidance in `.coderabbit.yaml` steers the free reviewer toward:
+
+| Path | Focus |
+|------|--------|
+| `src/**` | Library API, auth, HTTP client, types (`woocommerce-rest-ts-api`) |
+| `packages/mcp-server/**` | MCP tools/resources, secrets, agent-facing errors (`woo-mcp-server`) |
+| `**/*.{test,spec}.*` | Meaningful tests, nock isolation |
+| `ui/**` | XSS / credentials in the demo UI |
+| `.github/workflows/**` | Permissions, secrets, dual-publish safety |
+| `scripts/**` | Publish scripts and token handling |
+| `docs/**` | Accuracy for install/publish/MCP |
+
+Generated and lockfile noise is excluded via `path_filters` (`dist/`, `coverage/`, `node_modules/`, `pnpm-lock.yaml`, images, etc.).
+
+## Free tier notes
+
+- `enable_free_tier: true` keeps free features available for users not on a paid plan.
+- Review **profile** is `chill` (fewer nits). Switch to `assertive` in YAML if you want stricter feedback.
+- CodeRabbit does **not** replace CI (Jest, typecheck, Snyk, publish workflows). Treat it as an extra review pass.
+- Paid plans add org features and higher limits; this repo is configured to work well on the free public-repo path.
+
+## Verify it works
+
+1. Install the GitHub App (steps above).
+2. Open a small non-draft PR against `main` (this docs/config PR is a good first run).
+3. Within a few minutes you should see:
+   - A commit status from CodeRabbit (if `commit_status` is enabled), and
+   - A walkthrough comment from **`@coderabbitai`**.
+4. If nothing appears, re-check App install on the correct repo and comment `@coderabbitai review`.
+
+## Related docs
+
+- [Publishing dual npm packages](./PUBLISHING.md)
+- [Security policy](../SECURITY.md)
+- [CodeRabbit configuration reference](https://docs.coderabbit.ai/reference/configuration)


### PR DESCRIPTION
## Summary
- Add [`.coderabbit.yaml`](.coderabbit.yaml) for **CodeRabbit free-tier** automatic PR reviews on this public monorepo
- Document one-time GitHub App install and usage in [`docs/CODERABBIT.md`](docs/CODERABBIT.md)
- Point contributors at CodeRabbit from the README

## Config highlights
- `enable_free_tier: true`, review profile **`chill`**
- Auto-review on non-draft PRs; skip Dependabot/Renovate/WIP titles
- Path instructions for `src/` (library), `packages/mcp-server/` (MCP), tests, UI, workflows, scripts, docs
- Exclude `dist/`, `coverage/`, lockfiles, and image noise
- Tools: ESLint, ShellCheck, Gitleaks, actionlint, yamllint, semgrep, etc.

## Owner action required (cannot automate)
CodeRabbit only reviews after the **GitHub App** is installed on this repo:

1. https://app.coderabbit.ai/login (sign in with GitHub)
2. Add **`Yuri-Lima/woocommerce-rest-api-ts-lib`**
3. On this PR, optionally comment: `@coderabbitai review`

## Test plan
- [ ] Install CodeRabbit GitHub App on this public repo
- [ ] Confirm `@coderabbitai` posts a walkthrough on this PR (or after `@coderabbitai review`)
- [ ] Confirm bot PRs (Dependabot) are not auto-reviewed once bots open PRs
- [ ] YAML validated against https://coderabbit.ai/integrations/schema.v2.json