### PR TITLE
perf(mcp): cut tool payload tokens and improve rate-limit memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ A modern, type-safe TypeScript client for the [WooCommerce REST API](https://woo
 | Package | Role |
 |---------|------|
 | [`woocommerce-rest-ts-api`](https://www.npmjs.com/package/woocommerce-rest-ts-api) | Typed HTTP client (OAuth 1.0a, retries, throttling, ESM + CJS) |
-| [`woo-mcp-server`](./packages/mcp-server/README.md) | MCP STDIO server — 60+ tools, resources, prompts for Claude / agents |
+| [`woo-mcp-server`](./packages/mcp-server/README.md) | MCP STDIO server — 80+ tools, resources, prompts, token usage for Claude / agents |
 
 ---
 
@@ -60,11 +60,21 @@ Release both: `pnpm run publish:packages` (or GitHub Action **Release npm packag
 
 **Highlights**
 
-- 60+ purpose-built tools (`woo_products_list`, `woo_orders_get`, …) with Zod I/O validation  
+- 80+ purpose-built tools (`woo_products_list`, `woo_orders_get`, refunds, reviews, …) with Zod I/O validation  
+- **Always-on token usage** — every tool result includes estimated payload tokens; hosts can record LLM rounds and audit with `woo_usage_stats`  
 - Resources: `woo://store/info`, `woo://api/schema`  
 - Prompts: `store-audit`, `order-report`, `inventory-check`  
 - Rate limiting, fail-fast env config, structured errors  
 - Live-tested on WooCommerce **10.9.3** (Docker stack under `scripts/live-wc/`)
+
+**Token usage (summary)** — full guide: [packages/mcp-server/README.md#token-usage](./packages/mcp-server/README.md#token-usage)
+
+| What | How |
+|------|-----|
+| Tool response cost | Every JSON tool result includes `usage.estimated_response_tokens` (+ `_meta["woo.usage"]`) |
+| Host model (Claude/GPT) cost | Call `woo_model_usage_record` after each API round, or use exported `ModelUsageTracker` |
+| Session audit | `woo_usage_stats` returns tool + model totals for the process |
+| Low-cost Anthropic smoke | `node packages/mcp-server/scripts/anthropic-mcp-smoke.mjs` (always prints token totals) |
 
 **Full package docs:** [packages/mcp-server/README.md](./packages/mcp-server/README.md)
 

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -47,13 +47,18 @@ Or open the static files directly:
 
 - **80+ purpose-built tools** — `woo_{resource}_{action}` naming (no catch-all HTTP free-for-all)
 - **Zod input + output validation** on every tool
+- **Always-on token / usage reporting** — every tool result includes estimated payload tokens; host LLM rounds can be recorded and audited (see [Token usage](#token-usage))
 - **Pagination metadata** (`total`, `totalPages`, `currentPage`) on list tools
 - **Search tools** for products and customers; rich order filters
+- **Order refunds** and **product reviews** CRUD for support / moderation agents
 - **Batch tools** for products and orders (ERP-style sync)
 - **Resources**: `woo://store/info`, `woo://api/schema`
 - **Prompts**: `store-audit`, `order-report`, `inventory-check`
 - **STDIO transport** — Claude Desktop compatible
-- **Rate limiting** via `WC_RATE_LIMIT_PER_SECOND` (default `5`)
+- **Token-bucket rate limiting** via `WC_RATE_LIMIT_PER_SECOND` (default `5`) — single throttle point (no double-limit with the REST library)
+- **Compact tool payloads** — JSON without pretty-print whitespace; list tools default to `detail=summary` (`_fields` projection)
+- **Slim system status** — `woo_system_status_get` defaults to a health-check summary (full report on demand)
+- **Bounded error/session memory** — truncated error details, capped usage ring buffers
 - **Fail-fast config** — missing `WC_URL` / `WC_KEY` / `WC_SECRET` aborts with a clear message
 - **Live-tested** against WooCommerce **10.9.3** (Docker) — see [Live testing](#live-testing)
 
@@ -157,11 +162,14 @@ Add to `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS)
 ```
 AI client (Claude Desktop / custom MCP agent)
         │  MCP over STDIO
+        │  (host records model token usage → woo_model_usage_record)
         ▼
 ┌─────────────────────────────────┐
 │  woo-mcp-server                │
 │  • Zod input validation         │
 │  • Domain tool handlers         │
+│  • Always-on payload usage      │
+│  • Session usage rollups        │
 │  • Rate limiter                 │
 │  • Error normalization          │
 │  • Zod output validation        │
@@ -181,12 +189,187 @@ Walk through these end-to-end in the [developer presentation](../../ui/presentat
 
 | # | Scenario | Primary tools / prompts |
 |---|----------|-------------------------|
-| 1 | **Support copilot** — “Where is my order?” | `woo_customers_search` → `woo_orders_list` / `get` → `woo_orders_notes_create` |
+| 1 | **Support copilot** — “Where is my order?” | `woo_customers_search` → `woo_orders_list` / `get` → `woo_orders_notes_create` / refunds |
 | 2 | **Inventory ops** — weekly low-stock list | prompt `inventory-check` + `woo_products_list` / variations |
 | 3 | **Sales report agent** — monthly narrative | prompt `order-report` + `woo_reports_*` |
 | 4 | **Catalog SEO audit** | prompt `store-audit` (read-only until human approves updates) |
 | 5 | **Bulk import / price sync** | `woo_products_batch` / `woo_orders_batch` |
 | 6 | **Custom agent runtime** | MCP SDK client over STDIO (see presentation slide) |
+| 7 | **Cost-aware agent** — audit LLM + tool cost | tool `usage` field + `woo_usage_stats` / `woo_model_usage_record` |
+
+---
+
+## Token usage
+
+Agents that call many tools (or multi-round tool loops with Claude / GPT) need a clear cost signal. `woo-mcp-server` always surfaces usage in two layers:
+
+| Layer | What it measures | Where you see it |
+|-------|------------------|------------------|
+| **Tool payload usage** | Size of each MCP tool response (chars + estimated tokens) | On **every** successful object result as `usage`, and on MCP `_meta["woo.usage"]` |
+| **Host model usage** | Real LLM API tokens (`input_tokens` / `output_tokens`) from Anthropic, OpenAI, etc. | Recorded via `woo_model_usage_record` or `ModelUsageTracker`, then read with `woo_usage_stats` |
+
+The MCP server does **not** call Anthropic/OpenAI itself. Model tokens only exist on the **host** that runs the model. Hosts should record each round so the session stays auditable.
+
+### Always-on tool payload `usage`
+
+Every successful tool that returns a JSON object includes a `usage` field (payload estimate only — not WooCommerce API billing):
+
+```json
+{
+  "items": [ { "id": 12, "name": "Green Mug" } ],
+  "pagination": {
+    "total": 3,
+    "totalPages": 1,
+    "currentPage": 1,
+    "perPage": 2
+  },
+  "usage": {
+    "response_chars": 3854,
+    "estimated_response_tokens": 964,
+    "at": "2026-07-08T09:31:35.892Z"
+  }
+}
+```
+
+The same estimate is attached as MCP metadata:
+
+```json
+{
+  "_meta": {
+    "woo.usage": {
+      "response_chars": 3854,
+      "estimated_response_tokens": 964,
+      "at": "2026-07-08T09:31:35.892Z"
+    }
+  }
+}
+```
+
+**Estimate formula:** `estimated_response_tokens = max(1, ceil(response_chars / 4))` for the business payload (before the `usage` object is attached). This is a stable cost signal for agents, not a billing-grade tokenizer.
+
+Errors also carry `_meta["woo.usage"]` (with `is_error: true`) so failed calls still count toward session rollups.
+
+### Usage tools
+
+| Tool | Description | Required |
+|------|-------------|---------|
+| `woo_usage_stats` | Session snapshot: tool-call counts, estimated response tokens by tool, and any recorded model totals | — |
+| `woo_model_usage_record` | Push one host LLM round into the session (provider, model, input/output tokens, optional cache fields) | `input_tokens`, `output_tokens` |
+
+Optional args:
+
+| Tool | Optional fields |
+|------|-----------------|
+| `woo_usage_stats` | `reset` — if `true`, clear session counters after returning the snapshot |
+| `woo_model_usage_record` | `provider` (default `anthropic`), `model`, `cache_creation_input_tokens`, `cache_read_input_tokens`, `stop_reason`, `round` |
+
+Example — record an Anthropic Messages API round, then audit:
+
+```json
+// tools/call woo_model_usage_record
+{
+  "provider": "anthropic",
+  "model": "claude-haiku-4-5-20251001",
+  "input_tokens": 1650,
+  "output_tokens": 59,
+  "stop_reason": "tool_use",
+  "round": 1
+}
+```
+
+```json
+// tools/call woo_usage_stats → (shape)
+{
+  "tools": {
+    "tool_calls": 3,
+    "error_calls": 0,
+    "total_response_chars": 6328,
+    "total_estimated_response_tokens": 1584,
+    "by_tool": { "woo_products_list": { "calls": 1, "estimated_response_tokens": 964 } },
+    "recent": [ /* last N tool results */ ]
+  },
+  "models": {
+    "reports": 1,
+    "totals": {
+      "rounds": 1,
+      "input_tokens": 1650,
+      "output_tokens": 59,
+      "total_tokens": 1709,
+      "by_model": { "claude-haiku-4-5-20251001": { "rounds": 1, "total_tokens": 1709 } }
+    }
+  },
+  "usage": { "response_chars": 350, "estimated_response_tokens": 88, "at": "..." }
+}
+```
+
+### Programmatic host: `ModelUsageTracker`
+
+When you build a custom agent (MCP SDK client + Anthropic/OpenAI), use the exported tracker so **every multi-round loop always ends with totals**:
+
+```ts
+import {
+  createServer,
+  ModelUsageTracker,
+} from "woo-mcp-server";
+
+const modelUsage = new ModelUsageTracker("anthropic");
+
+// after each Messages API response:
+modelUsage.addRound(response.usage, {
+  model: "claude-haiku-4-5-20251001",
+  stop_reason: response.stop_reason,
+});
+
+// after the tool loop finishes — always call finalize():
+const report = modelUsage.finalize();
+// report.totals.input_tokens / output_tokens / total_tokens
+// report.rounds[] — per-round breakdown
+// also stored in the process session → visible via woo_usage_stats
+```
+
+`ModelUsageTracker` accepts Anthropic-style (`input_tokens` / `output_tokens`) and OpenAI-style (`prompt_tokens` / `completion_tokens`) usage objects.
+
+### Anthropic smoke script (low token cost)
+
+From the package (with a live store + `ANTHROPIC_API_KEY`):
+
+```bash
+export ANTHROPIC_API_KEY=sk-ant-...
+export WC_URL=http://127.0.0.1:8088
+export WC_KEY=ck_...
+export WC_SECRET=cs_...
+export WC_QUERY_STRING_AUTH=false   # local HTTP Docker
+
+# Optional: ANTHROPIC_MODEL (default claude-haiku-4-5-20251001)
+# Optional: ANTHROPIC_MAX_TOKENS (default 256)
+node packages/mcp-server/scripts/anthropic-mcp-smoke.mjs
+```
+
+The script:
+
+1. Exposes only a **small** tool subset to Claude (keeps prompt tokens low).
+2. Runs a short tool-use loop against the live store.
+3. **Always** prints per-round and total model usage under `--- TOKEN USAGE ---`.
+4. Prints MCP session usage (`woo_usage_stats`) under `--- MCP SESSION USAGE ---`.
+
+Full live tool sweep (no Anthropic tokens):
+
+```bash
+node packages/mcp-server/scripts/live-endpoint-sweep.mjs
+```
+
+### Recommended agent pattern
+
+```
+for each user task:
+  call model with tools
+  while stop_reason == tool_use:
+    execute MCP tools          → each result includes usage.estimated_response_tokens
+    modelUsage.addRound(...)   → or woo_model_usage_record
+    call model again with tool_results
+  modelUsage.finalize()        → always return totals to logs / user / metrics
+  optional: woo_usage_stats    → full session audit
+```
 
 ---
 
@@ -198,7 +381,7 @@ Naming: `woo_{resource}_{action}`. Every tool description is multi-sentence (wha
 
 | Tool | Description | Required |
 |------|-------------|---------|
-| `woo_products_list` | List products with filters & pagination | — |
+| `woo_products_list` | List products (default `detail=summary` slim `_fields`) | — |
 | `woo_products_get` | Get product by ID | `id` |
 | `woo_products_create` | Create product | `name` |
 | `woo_products_update` | Update product fields | `id`, `data` |
@@ -210,7 +393,7 @@ Naming: `woo_{resource}_{action}`. Every tool description is multi-sentence (wha
 
 | Tool | Description | Required |
 |------|-------------|---------|
-| `woo_orders_list` | List orders (status, dates, customer) | — |
+| `woo_orders_list` | List orders (default `detail=summary` slim `_fields`) | — |
 | `woo_orders_get` | Get order by ID | `id` |
 | `woo_orders_create` | Create order | — |
 | `woo_orders_update` | Update order | `id`, `data` |
@@ -227,7 +410,7 @@ Naming: `woo_{resource}_{action}`. Every tool description is multi-sentence (wha
 
 | Tool | Description | Required |
 |------|-------------|---------|
-| `woo_customers_list` | List customers | — |
+| `woo_customers_list` | List customers (default `detail=summary` slim `_fields`) | — |
 | `woo_customers_get` | Get customer | `id` |
 | `woo_customers_create` | Create customer | `email` |
 | `woo_customers_update` | Update customer | `id`, `data` |
@@ -300,7 +483,7 @@ Naming: `woo_{resource}_{action}`. Every tool description is multi-sentence (wha
 | `woo_reports_coupons_totals` | Coupon totals | — |
 | `woo_reports_reviews_totals` | Review totals | — |
 
-### Settings · system status · webhooks · tax
+### Settings · system status · webhooks · tax · usage
 
 | Domain | Tools |
 |--------|--------|
@@ -308,8 +491,7 @@ Naming: `woo_{resource}_{action}`. Every tool description is multi-sentence (wha
 | System status | `woo_system_status_get`, `woo_system_status_tools_list`, `woo_system_status_tools_run` |
 | Webhooks | `woo_webhooks_list` / `get` / `create` / `update` / `delete` |
 | Tax | `woo_tax_rates_*`, `woo_tax_classes_list` / `get` |
-| Reviews | `woo_reviews_list` / `get` / `create` / `update` / `delete` |
-| Usage | `woo_usage_stats`, `woo_model_usage_record` — tool payload + model token usage |
+| Usage | `woo_usage_stats`, `woo_model_usage_record` — see [Token usage](#token-usage) |
 
 ---
 
@@ -330,6 +512,30 @@ Naming: `woo_{resource}_{action}`. Every tool description is multi-sentence (wha
 
 ---
 
+## Performance & memory
+
+High-volume agent loops pay for every byte returned as model input tokens. The server defaults to lean payloads:
+
+| Optimization | Default | Escape hatch |
+|--------------|---------|--------------|
+| Compact JSON (`textContent`) | no pretty-print | n/a (always compact) |
+| List `_fields` projection | `detail=summary` on products / orders / customers lists | `detail=full` or custom `fields` |
+| System status | `detail=summary` slim health report | `detail=full`, optional `sections` |
+| Rate limit | token bucket at MCP layer only | `WC_RATE_LIMIT_PER_SECOND` |
+| Errors | details capped (~500 chars) | n/a |
+| Usage session | recent tool/model rings capped | n/a |
+
+Prove impact after build:
+
+```bash
+pnpm --filter woo-mcp-server build
+pnpm --filter woo-mcp-server bench:perf
+```
+
+The bench fails the process if any case misses its minimum savings threshold (compact JSON, field projection, system status, error caps, rate-limiter burst, combined list payload).
+
+---
+
 ## Development
 
 ```bash
@@ -338,6 +544,7 @@ pnpm install
 pnpm run build                          # library + mcp-server
 pnpm --filter woo-mcp-server test       # unit + integration (nock; ≥80% coverage)
 pnpm --filter woo-mcp-server typecheck
+pnpm --filter woo-mcp-server bench:perf # impact proof for perf/memory opts
 ```
 
 ### Package layout
@@ -345,18 +552,25 @@ pnpm --filter woo-mcp-server typecheck
 ```
 packages/mcp-server/
   src/
-    server.ts          # MCP bootstrap (STDIO)
+    server.ts          # MCP bootstrap (STDIO); exports ModelUsageTracker + perf helpers
     cli.ts             # bin entry (woo-mcp-server)
     config.ts          # env validation
-    client.ts          # rate-limited WooCommerce client + cleanParams
-    types.ts           # shared Zod schemas
-    errors.ts          # MCP error normalization
+    client.ts          # token-bucket RateLimiter + WooCommerce client
+    types.ts           # Zod schemas + compact textContent + list field projection
+    usage.ts           # payload estimates + session + ModelUsageTracker (capped)
+    errors.ts          # MCP error normalization (+ truncated details)
     registry.ts        # registers all tools/resources/prompts
-    tools/             # one file per domain
+    tools/             # one file per domain (incl. usage.ts, reviews.ts)
     resources/
     prompts/
+  scripts/
+    anthropic-mcp-smoke.mjs   # Claude + MCP smoke; always prints token usage
+    live-endpoint-sweep.mjs   # exercise all tools against a live store
+    bench-perf.mjs            # performance / memory impact proof
   tests/
     tools/
+    usage.test.ts
+    system-status-slim.test.ts
     integration/       # e2e (in-memory MCP) + live-store (opt-in)
     fixtures/
 ```
@@ -377,6 +591,14 @@ pnpm --filter woo-mcp-server test -- tests/integration/live-store.test.ts
 ```
 
 See [`scripts/live-wc/README.md`](../../scripts/live-wc/README.md). Proven against **WordPress 7 + WooCommerce 10.9.3** over OAuth on `http://127.0.0.1:8088`.
+
+Optional: full tool sweep and Anthropic usage smoke (requires keys):
+
+```bash
+node packages/mcp-server/scripts/live-endpoint-sweep.mjs
+# with ANTHROPIC_API_KEY set:
+node packages/mcp-server/scripts/anthropic-mcp-smoke.mjs
+```
 
 ---
 

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -57,6 +57,7 @@
     "test": "node --experimental-vm-modules ../../node_modules/jest/bin/jest.js --config jest.config.cjs --coverage",
     "test:unit": "node --experimental-vm-modules ../../node_modules/jest/bin/jest.js --config jest.config.cjs --testPathPattern=tests/tools",
     "start": "node dist/cli.js",
+    "bench:perf": "node scripts/bench-perf.mjs",
     "clean": "rm -rf dist coverage",
     "prepublishOnly": "pnpm run build",
     "prepack": "pnpm run build"

--- a/packages/mcp-server/scripts/bench-perf.mjs
+++ b/packages/mcp-server/scripts/bench-perf.mjs
@@ -1,0 +1,373 @@
+#!/usr/bin/env node
+/**
+ * Performance / memory impact proof for MCP server optimizations.
+ *
+ * Measures before/after deltas for:
+ *  1. Compact JSON vs pretty-print (textContent)
+ *  2. Product list field projection (summary vs full)
+ *  3. System status slim vs full
+ *  4. Error detail truncation
+ *  5. Token-bucket RateLimiter burst vs legacy spacing chain
+ *  6. Combined list tool payload (compact + summary)
+ *
+ * Prerequisites: pnpm --filter woo-mcp-server build
+ * Run: pnpm --filter woo-mcp-server bench:perf
+ * Exit 0 only if every case meets its minimum impact threshold.
+ */
+
+import { performance } from "node:perf_hooks";
+import {
+  compactJson,
+  textContent,
+  PRODUCT_SUMMARY_FIELDS,
+  resolveListFields,
+  estimateTokensFromText,
+  RateLimiter,
+  slimSystemStatus,
+  formatErrorDetails,
+  MAX_ERROR_DETAILS_CHARS,
+} from "../dist/server.js";
+
+function projectFields(item, fieldsCsv) {
+  const keys = fieldsCsv.split(",").map((s) => s.trim());
+  const out = {};
+  for (const k of keys) {
+    if (k in item) out[k] = item[k];
+  }
+  return out;
+}
+
+function makeProduct(i) {
+  return {
+    id: i,
+    name: `Product ${i}`,
+    slug: `product-${i}`,
+    permalink: `https://shop.example/product/product-${i}`,
+    type: "simple",
+    status: "publish",
+    description:
+      "<p>" +
+      "A long HTML product description that appears in full REST responses. ".repeat(12) +
+      "</p>",
+    short_description: `<p>Short excerpt for product ${i}</p>`,
+    sku: `SKU-${i}`,
+    price: "29.99",
+    regular_price: "29.99",
+    sale_price: "",
+    stock_quantity: 50,
+    stock_status: "instock",
+    manage_stock: true,
+    categories: [{ id: 15, name: "Apparel", slug: "apparel" }],
+    tags: [{ id: 3, name: "summer", slug: "summer" }],
+    images: Array.from({ length: 4 }, (_, j) => ({
+      id: i * 10 + j,
+      src: `https://cdn.example/img/${i}-${j}.jpg`,
+      name: `Image ${j}`,
+      alt: `Alt text for image ${j} of product ${i}`,
+    })),
+    meta_data: Array.from({ length: 8 }, (_, j) => ({
+      id: j,
+      key: `_custom_meta_${j}`,
+      value: "v".repeat(40),
+    })),
+    attributes: [],
+    default_attributes: [],
+    variations: [],
+    menu_order: 0,
+  };
+}
+
+function makeSystemStatus() {
+  return {
+    environment: {
+      home_url: "http://localhost:8088",
+      site_url: "http://localhost:8088",
+      version: "9.0.0",
+      wp_version: "6.5",
+      php_version: "8.2",
+      mysql_version: "8.0",
+      mysql_version_string: "8.0.36",
+      wc_version: "9.0.0",
+      server_info: "nginx/1.25",
+      memory_limit: "256M",
+      max_execution_time: "300",
+      wp_memory_limit: "256M",
+      wp_debug_mode: false,
+      wp_cron: true,
+      language: "en_US",
+      external_object_cache: false,
+      sudo: false,
+      remote_post_response: "200",
+      remote_get_response: "200",
+      default_timezone: "UTC",
+      fsockopen_or_curl_enabled: true,
+      soapclient_enabled: true,
+      domdocument_enabled: true,
+      gzip_enabled: true,
+      mbstring_enabled: true,
+      remote_post_successful: true,
+      remote_get_successful: true,
+    },
+    database: {
+      wc_database_version: "9.0.0",
+      database_prefix: "wp_",
+      maxmind_geoip_database: "",
+      database_size: { data: "120MB", index: "40MB" },
+      database_tables: Object.fromEntries(
+        Array.from({ length: 60 }, (_, i) => [
+          `wp_table_${i}`,
+          { data: "1.2MB", index: "0.4MB", engine: "InnoDB" },
+        ]),
+      ),
+    },
+    active_plugins: Array.from({ length: 35 }, (_, i) => ({
+      plugin: `plugin-${i}/plugin.php`,
+      name: `Plugin ${i}`,
+      version: "1.2.3",
+      version_latest: "1.2.3",
+      author_name: "Author Name",
+      network_activated: false,
+      author_url: "https://example.com/author/" + "a".repeat(60),
+      plugin_uri: "https://example.com/plugin/" + "b".repeat(60),
+    })),
+    theme: {
+      name: "Storefront",
+      version: "4.5.0",
+      version_latest: "4.5.0",
+      author_url: "https://woocommerce.com",
+      is_child_theme: false,
+      has_woocommerce_support: true,
+      has_woocommerce_file: true,
+      has_outdated_templates: false,
+      overrides: Array.from({ length: 20 }, (_, i) => `template-${i}.php`),
+      parent_name: "",
+      parent_version: "",
+      parent_author_url: "",
+    },
+    settings: {
+      currency: "USD",
+      currency_symbol: "$",
+      currency_position: "left",
+      number_of_decimals: 2,
+      thousand_separator: ",",
+      decimal_separator: ".",
+      taxonomies: { product_type: "product_type" },
+      product_visibility_terms: Object.fromEntries(
+        Array.from({ length: 10 }, (_, i) => [`term_${i}`, `val_${i}`]),
+      ),
+      woocommerce_api_enabled: true,
+      woocommerce_calc_taxes: "yes",
+      force_ssl: false,
+    },
+    security: { secure_connection: false, hide_errors: true },
+    pages: Array.from({ length: 8 }, (_, i) => ({
+      page_name: `Page ${i}`,
+      page_id: i,
+      page_set: i > 0,
+      page_exists: i > 0,
+      page_visible: true,
+      shortcode: "[woocommerce]",
+      shortcode_required: true,
+      shortcode_present: true,
+    })),
+  };
+}
+
+/** Legacy spacing RateLimiter for comparison (pre-optimization behavior). */
+class SpacingRateLimiter {
+  constructor(rps) {
+    this.intervalMs = Math.ceil(1000 / Math.max(1, rps));
+    this.lastRequestAt = 0;
+    this.chain = Promise.resolve();
+  }
+  async schedule(fn) {
+    const run = this.chain.then(async () => {
+      const now = Date.now();
+      const wait = Math.max(0, this.lastRequestAt + this.intervalMs - now);
+      if (wait > 0) await new Promise((r) => setTimeout(r, wait));
+      this.lastRequestAt = Date.now();
+    });
+    this.chain = run.catch(() => undefined);
+    await run;
+    return fn();
+  }
+}
+
+function pctSaved(before, after) {
+  return ((before - after) / before) * 100;
+}
+
+function row(name, before, after, unit, minPct, okExtra = true) {
+  const saved = pctSaved(before, after);
+  const ok = saved >= minPct && okExtra;
+  return { name, before, after, unit, saved, minPct, ok };
+}
+
+async function main() {
+  const results = [];
+  const products = Array.from({ length: 20 }, (_, i) => makeProduct(i + 1));
+  const listPayload = {
+    items: products,
+    pagination: { total: 20, totalPages: 1, currentPage: 1, perPage: 20 },
+  };
+
+  // ── 1. Compact vs pretty JSON ────────────────────────────────────────────
+  const pretty = JSON.stringify(listPayload, null, 2);
+  const compactViaText = textContent(listPayload, { includeUsage: false }).content[0]
+    .text;
+  // Sanity: compactJson matches textContent path without usage
+  if (compactJson(listPayload) !== compactViaText) {
+    throw new Error("compactJson / textContent mismatch");
+  }
+  results.push(
+    row(
+      "1. Compact JSON (list of 20 products)",
+      pretty.length,
+      compactViaText.length,
+      "chars",
+      20,
+    ),
+  );
+
+  // ── 2. Field projection ──────────────────────────────────────────────────
+  const fields = resolveListFields("summary", undefined, PRODUCT_SUMMARY_FIELDS);
+  const slimItems = products.map((p) => projectFields(p, fields));
+  const fullSize = JSON.stringify({ items: products }).length;
+  const slimSize = JSON.stringify({ items: slimItems }).length;
+  results.push(
+    row("2. Product list _fields summary (20 items)", fullSize, slimSize, "chars", 45),
+  );
+
+  // ── 3. System status slim ────────────────────────────────────────────────
+  const status = makeSystemStatus();
+  const slimStatus = slimSystemStatus(status);
+  const fullStatusSize = JSON.stringify(status).length;
+  const slimStatusSize = JSON.stringify(slimStatus).length;
+  results.push(
+    row(
+      "3. System status summary vs full",
+      fullStatusSize,
+      slimStatusSize,
+      "chars",
+      50,
+    ),
+  );
+
+  // ── 4. Error truncation ──────────────────────────────────────────────────
+  const fatDetails = {
+    code: "internal_server_error",
+    message: "Database error",
+    data: { html: "<html>" + "x".repeat(8000) + "</html>" },
+  };
+  const untruncated = JSON.stringify(fatDetails);
+  const truncated = formatErrorDetails(fatDetails);
+  results.push(
+    row(
+      "4. Error details truncation",
+      untruncated.length,
+      truncated.length,
+      "chars",
+      85,
+      truncated.length <= MAX_ERROR_DETAILS_CHARS + 40,
+    ),
+  );
+
+  // ── 5. Rate limiter burst latency ────────────────────────────────────────
+  const rps = 20;
+  const jobs = 15; // within bucket capacity; spacing serializes all
+
+  const spacing = new SpacingRateLimiter(rps);
+  const t0 = performance.now();
+  await Promise.all(
+    Array.from({ length: jobs }, () => spacing.schedule(async () => undefined)),
+  );
+  const spacingMs = performance.now() - t0;
+
+  const bucket = new RateLimiter(rps, 8);
+  const t1 = performance.now();
+  await Promise.all(
+    Array.from({ length: jobs }, () => bucket.schedule(async () => undefined)),
+  );
+  const tokenMs = performance.now() - t1;
+
+  const latencySaved = pctSaved(spacingMs, tokenMs);
+  results.push({
+    name: "5. RateLimiter burst (15 jobs @ 20 RPS)",
+    before: Math.round(spacingMs),
+    after: Math.round(tokenMs),
+    unit: "ms",
+    saved: latencySaved,
+    minPct: 40,
+    ok: latencySaved >= 40 && tokenMs < spacingMs,
+  });
+
+  // ── 6. Combined MCP tool payload (compact + summary fields) ──────────────
+  const legacyToolText = JSON.stringify(
+    { items: products, pagination: listPayload.pagination },
+    null,
+    2,
+  );
+  const modernToolText = textContent(
+    {
+      items: slimItems,
+      pagination: listPayload.pagination,
+    },
+    { includeUsage: false },
+  ).content[0].text;
+  results.push(
+    row(
+      "6. Combined list tool payload (compact+summary)",
+      legacyToolText.length,
+      modernToolText.length,
+      "chars",
+      55,
+    ),
+  );
+
+  const legacyTokens = estimateTokensFromText(legacyToolText);
+  const modernTokens = estimateTokensFromText(modernToolText);
+
+  // ── Report ───────────────────────────────────────────────────────────────
+  console.log("\nMCP server performance / memory impact proof\n");
+  console.log(
+    "Case".padEnd(52) +
+      "Before".padStart(10) +
+      "After".padStart(10) +
+      "Saved".padStart(10) +
+      "  Min   Pass",
+  );
+  console.log("-".repeat(96));
+
+  let allOk = true;
+  for (const r of results) {
+    const mark = r.ok ? "✓" : "✗";
+    if (!r.ok) allOk = false;
+    console.log(
+      r.name.padEnd(52) +
+        String(r.before).padStart(10) +
+        String(r.after).padStart(10) +
+        `${r.saved.toFixed(1)}%`.padStart(10) +
+        `${r.minPct}%`.padStart(6) +
+        `  ${mark}`,
+    );
+  }
+
+  console.log("-".repeat(96));
+  console.log(
+    `\nEstimated model tokens for 20-product list tool result:\n` +
+      `  legacy (pretty + full):     ~${legacyTokens} tokens\n` +
+      `  modern (compact + summary): ~${modernTokens} tokens\n` +
+      `  reduction: ${pctSaved(legacyTokens, modernTokens).toFixed(1)}%\n`,
+  );
+
+  if (!allOk) {
+    console.error("FAILED: one or more cases did not meet impact thresholds.");
+    process.exit(1);
+  }
+  console.log("All impact thresholds met.\n");
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/packages/mcp-server/src/client.ts
+++ b/packages/mcp-server/src/client.ts
@@ -63,40 +63,90 @@ export class ConcurrencyThrottler implements Throttler {
 }
 
 /**
- * Rate limiter: enforces a maximum number of operations per second
- * using a sliding window + the Throttler concurrency gate.
+ * Token-bucket rate limiter + optional concurrency gate.
+ *
+ * Previous spacing chain serialized every start at 1000/RPS ms, which:
+ * - forbade bursts even when the bucket had capacity
+ * - stacked with the library's own Throttler (double throttle)
+ *
+ * Token bucket allows up to `requestsPerSecond` burst tokens, refilling at
+ * `requestsPerSecond` tokens/sec. Concurrent in-flight work is limited
+ * separately so slow WC responses do not starve the queue.
  */
 export class RateLimiter {
-  private readonly intervalMs: number;
+  private tokens: number;
+  private readonly maxTokens: number;
+  private readonly refillPerMs: number;
+  private lastRefillMs: number;
   private readonly throttler: Throttler;
-  private lastRequestAt = 0;
-  private chain: Promise<void> = Promise.resolve();
+  /** FIFO of waiters when the bucket is empty */
+  private waiters: Array<() => void> = [];
+  private timer: ReturnType<typeof setTimeout> | null = null;
 
   constructor(requestsPerSecond: number, maxConcurrent?: number) {
-    this.intervalMs = Math.ceil(1000 / Math.max(1, requestsPerSecond));
-    // Align concurrent slots with rate limit (library Throttler pattern)
+    const rps = Math.max(1, requestsPerSecond);
+    this.maxTokens = rps;
+    this.tokens = rps;
+    this.refillPerMs = rps / 1000;
+    this.lastRefillMs = Date.now();
+    // Cap default concurrency so a burst does not open unbounded sockets.
+    // Library-side maxConcurrentRequests is disabled (0) — single throttle point.
     this.throttler = new ConcurrencyThrottler(
-      maxConcurrent ?? Math.max(1, requestsPerSecond),
+      maxConcurrent ?? Math.min(rps, 8),
     );
+  }
+
+  private refill(): void {
+    const now = Date.now();
+    const elapsed = now - this.lastRefillMs;
+    if (elapsed <= 0) return;
+    this.tokens = Math.min(this.maxTokens, this.tokens + elapsed * this.refillPerMs);
+    this.lastRefillMs = now;
+  }
+
+  private scheduleWake(): void {
+    if (this.timer || this.waiters.length === 0) return;
+    // Time until one full token is available
+    const need = 1 - this.tokens;
+    const waitMs = Math.max(1, Math.ceil(need / this.refillPerMs));
+    this.timer = setTimeout(() => {
+      this.timer = null;
+      this.refill();
+      this.drainWaiters();
+    }, waitMs);
+    // Don't keep the process alive solely for rate-limit timers
+    if (typeof this.timer === "object" && "unref" in this.timer) {
+      this.timer.unref();
+    }
+  }
+
+  private drainWaiters(): void {
+    this.refill();
+    while (this.waiters.length > 0 && this.tokens >= 1) {
+      this.tokens -= 1;
+      const next = this.waiters.shift()!;
+      next();
+    }
+    if (this.waiters.length > 0) this.scheduleWake();
+  }
+
+  private acquireToken(): Promise<void> {
+    this.refill();
+    if (this.tokens >= 1 && this.waiters.length === 0) {
+      this.tokens -= 1;
+      return Promise.resolve();
+    }
+    return new Promise<void>((resolve) => {
+      this.waiters.push(resolve);
+      this.scheduleWake();
+    });
   }
 
   /**
    * Schedule `fn` to run respecting both rate and concurrency limits.
    */
   async schedule<T>(fn: () => Promise<T>): Promise<T> {
-    // Serialize start times so we never exceed N starts per second
-    const run = this.chain.then(async () => {
-      const now = Date.now();
-      const wait = Math.max(0, this.lastRequestAt + this.intervalMs - now);
-      if (wait > 0) {
-        await new Promise((r) => setTimeout(r, wait));
-      }
-      this.lastRequestAt = Date.now();
-    });
-    // Keep chain alive even if a prior task rejects
-    this.chain = run.catch(() => undefined);
-    await run;
-
+    await this.acquireToken();
     await this.throttler.acquire();
     try {
       return await fn();
@@ -172,9 +222,11 @@ export interface WooClient {
  * Create a rate-limited WooCommerce client from validated config.
  */
 export function createWooClient(config: McpConfig): WooClient {
+  // Single throttle point at MCP layer (token bucket + concurrency).
+  // Library maxConcurrentRequests=0 disables its internal Throttler so we
+  // never double-limit and pay latency twice on every request.
   const rateLimiter = new RateLimiter(config.WC_RATE_LIMIT_PER_SECOND);
 
-  // Library's internal Throttler is engaged via maxConcurrentRequests.
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const ApiCtor = WooCommerceRestApi as any;
   const apiInstance = new ApiCtor({
@@ -183,7 +235,7 @@ export function createWooClient(config: McpConfig): WooClient {
     consumerSecret: config.WC_SECRET,
     version: config.WC_VERSION,
     queryStringAuth: config.WC_QUERY_STRING_AUTH,
-    maxConcurrentRequests: config.WC_RATE_LIMIT_PER_SECOND,
+    maxConcurrentRequests: 0,
   }) as WooApi;
 
   /**

--- a/packages/mcp-server/src/errors.ts
+++ b/packages/mcp-server/src/errors.ts
@@ -7,10 +7,16 @@
 import { WooCommerceApiError, AuthenticationError, OptionsException } from "woocommerce-rest-ts-api";
 import { usageMetaForText } from "./usage.js";
 
+/** Cap error detail blobs so a 50KB WC HTML/JSON error cannot flood the model context. */
+export const MAX_ERROR_DETAILS_CHARS = 500;
+export const MAX_ERROR_MESSAGE_CHARS = 400;
+
 export interface McpToolErrorPayload {
   isError: true;
   content: Array<{ type: "text"; text: string }>;
   _meta?: ReturnType<typeof usageMetaForText>;
+  /** Index signature so results assign to MCP SDK CallToolResult. */
+  [key: string]: unknown;
 }
 
 export interface NormalizedError {
@@ -18,6 +24,29 @@ export interface NormalizedError {
   message: string;
   status?: number;
   details?: unknown;
+}
+
+/** Truncate long strings with a visible remainder marker. */
+export function truncateText(text: string, maxChars: number): string {
+  if (text.length <= maxChars) return text;
+  const omitted = text.length - maxChars;
+  return `${text.slice(0, maxChars)}…[truncated ${omitted} chars]`;
+}
+
+/** Compact + truncate error details for model-facing messages. */
+export function formatErrorDetails(
+  details: unknown,
+  maxChars = MAX_ERROR_DETAILS_CHARS,
+): string | undefined {
+  if (details === undefined) return undefined;
+  let raw: string;
+  try {
+    raw = typeof details === "string" ? details : JSON.stringify(details);
+  } catch {
+    return undefined;
+  }
+  if (!raw) return undefined;
+  return truncateText(raw, maxChars);
 }
 
 function messageOf(err: unknown, fallback: string): string {
@@ -100,18 +129,17 @@ export function normalizeError(err: unknown): NormalizedError {
 
 /**
  * Format a normalized error as an MCP tool error result.
+ * Message and details are length-capped to protect model context / memory.
  */
 export function toMcpToolError(err: unknown): McpToolErrorPayload {
   const normalized = normalizeError(err);
+  const message = truncateText(normalized.message, MAX_ERROR_MESSAGE_CHARS);
   const parts = [
-    `Error [${normalized.code}]${normalized.status ? ` (HTTP ${normalized.status})` : ""}: ${normalized.message}`,
+    `Error [${normalized.code}]${normalized.status ? ` (HTTP ${normalized.status})` : ""}: ${message}`,
   ];
-  if (normalized.details !== undefined) {
-    try {
-      parts.push(`Details: ${JSON.stringify(normalized.details)}`);
-    } catch {
-      // ignore non-serializable details
-    }
+  const details = formatErrorDetails(normalized.details);
+  if (details !== undefined) {
+    parts.push(`Details: ${details}`);
   }
   const text = parts.join("\n");
   return {

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -8,7 +8,12 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { loadConfig, type McpConfig } from "./config.js";
-import { createWooClient, type WooClient } from "./client.js";
+import {
+  createWooClient,
+  RateLimiter,
+  ConcurrencyThrottler,
+  type WooClient,
+} from "./client.js";
 import { registerAll } from "./registry.js";
 
 export const SERVER_NAME = "woo-mcp-server";
@@ -72,13 +77,29 @@ export async function startServer(): Promise<CreatedServer> {
   return created;
 }
 
-export { loadConfig, createWooClient, registerAll };
+export { loadConfig, createWooClient, RateLimiter, ConcurrencyThrottler, registerAll };
 export {
   ModelUsageTracker,
   usageSession,
   estimateTokensFromText,
   buildToolPayloadUsage,
 } from "./usage.js";
+export {
+  compactJson,
+  textContent,
+  resolveListFields,
+  PRODUCT_SUMMARY_FIELDS,
+  ORDER_SUMMARY_FIELDS,
+  CUSTOMER_SUMMARY_FIELDS,
+} from "./types.js";
+export {
+  formatErrorDetails,
+  truncateText,
+  MAX_ERROR_DETAILS_CHARS,
+  MAX_ERROR_MESSAGE_CHARS,
+  toMcpToolError,
+} from "./errors.js";
+export { slimSystemStatus } from "./tools/system-status.js";
 export type { McpConfig, WooClient };
 export type {
   ModelUsageReport,

--- a/packages/mcp-server/src/tools/customers.ts
+++ b/packages/mcp-server/src/tools/customers.ts
@@ -7,11 +7,15 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { WooClient } from "../client.js";
 import { toMcpToolError } from "../errors.js";
 import {
+  CUSTOMER_SUMMARY_FIELDS,
   CustomerSchema,
   DeleteResponseSchema,
+  ListDetailSchema,
+  ListFieldsSchema,
   PaginationInputSchema,
   parseListOutput,
   parseSingleOutput,
+  resolveListFields,
   textContent,
 } from "../types.js";
 
@@ -33,7 +37,7 @@ export function registerCustomerTools(server: McpServer, client: WooClient): voi
     {
       title: "List customers",
       description:
-        "Lists WooCommerce customers with pagination. Use this for CRM-style overviews, segmenting audiences, or finding accounts before creating orders. Returns customer objects and pagination metadata.",
+        "Lists WooCommerce customers with pagination. Default detail=summary uses a slim `_fields` projection (no full address blobs) to cut tokens/memory — use detail=full or woo_customers_get for complete profiles. Returns customer objects and pagination metadata.",
       inputSchema: {
         ...PaginationInputSchema.shape,
         role: z.string().optional().describe("Filter by role, e.g. customer"),
@@ -43,12 +47,19 @@ export function registerCustomerTools(server: McpServer, client: WooClient): voi
           .optional()
           .describe("Sort field"),
         order: z.enum(["asc", "desc"]).optional().describe("Sort direction"),
+        detail: ListDetailSchema,
+        fields: ListFieldsSchema,
       },
     },
     async (args) => {
       try {
         const page = args.page ?? 1;
         const per_page = args.per_page ?? 10;
+        const _fields = resolveListFields(
+          args.detail,
+          args.fields,
+          CUSTOMER_SUMMARY_FIELDS,
+        );
         const res = await client.get<unknown[]>("customers", {
           page,
           per_page,
@@ -56,6 +67,7 @@ export function registerCustomerTools(server: McpServer, client: WooClient): voi
           email: args.email,
           orderby: args.orderby,
           order: args.order,
+          ...(_fields ? { _fields } : {}),
         });
         const meta = client.pagination(res, page, per_page);
         return textContent(
@@ -179,20 +191,28 @@ export function registerCustomerTools(server: McpServer, client: WooClient): voi
     {
       title: "Search customers",
       description:
-        "Searches customers by free-text query (name, email, username). Use this when the user provides a partial name or email and you need matching accounts before acting on orders.",
+        "Searches customers by free-text query (name, email, username). Default detail=summary uses a slim `_fields` projection. Use this when the user provides a partial name or email and you need matching accounts before acting on orders.",
       inputSchema: {
         query: z.string().min(1).describe("Search query. Example: \"jane@\""),
         ...PaginationInputSchema.shape,
+        detail: ListDetailSchema,
+        fields: ListFieldsSchema,
       },
     },
     async (args) => {
       try {
         const page = args.page ?? 1;
         const per_page = args.per_page ?? 10;
+        const _fields = resolveListFields(
+          args.detail,
+          args.fields,
+          CUSTOMER_SUMMARY_FIELDS,
+        );
         const res = await client.get<unknown[]>("customers", {
           search: args.query,
           page,
           per_page,
+          ...(_fields ? { _fields } : {}),
         });
         const meta = client.pagination(res, page, per_page);
         return textContent(

--- a/packages/mcp-server/src/tools/orders.ts
+++ b/packages/mcp-server/src/tools/orders.ts
@@ -10,12 +10,16 @@ import {
   BatchOperationSchema,
   BatchResponseSchema,
   DeleteResponseSchema,
+  ListDetailSchema,
+  ListFieldsSchema,
+  ORDER_SUMMARY_FIELDS,
   OrderNoteSchema,
   OrderRefundSchema,
   OrderSchema,
   PaginationInputSchema,
   parseListOutput,
   parseSingleOutput,
+  resolveListFields,
   textContent,
 } from "../types.js";
 
@@ -58,7 +62,7 @@ export function registerOrderTools(server: McpServer, client: WooClient): void {
     {
       title: "List orders",
       description:
-        "Lists store orders with pagination and optional filters for status, date range, and customer. Use this to build order queues, support lookups, or feed sales analysis. Returns order objects plus pagination metadata.",
+        "Lists store orders with pagination and optional filters for status, date range, and customer. Default detail=summary uses a slim `_fields` projection to cut tokens/memory — use detail=full or woo_orders_get for complete addresses/meta. Returns order objects plus pagination metadata.",
       inputSchema: {
         ...PaginationInputSchema.shape,
         status: z
@@ -85,12 +89,19 @@ export function registerOrderTools(server: McpServer, client: WooClient): void {
           .optional()
           .describe("Sort field"),
         order: z.enum(["asc", "desc"]).optional().describe("Sort direction"),
+        detail: ListDetailSchema,
+        fields: ListFieldsSchema,
       },
     },
     async (args) => {
       try {
         const page = args.page ?? 1;
         const per_page = args.per_page ?? 10;
+        const _fields = resolveListFields(
+          args.detail,
+          args.fields,
+          ORDER_SUMMARY_FIELDS,
+        );
         const res = await client.get<unknown[]>("orders", {
           page,
           per_page,
@@ -101,6 +112,7 @@ export function registerOrderTools(server: McpServer, client: WooClient): void {
           product: args.product,
           orderby: args.orderby,
           order: args.order,
+          ...(_fields ? { _fields } : {}),
         });
         const meta = client.pagination(res, page, per_page);
         const out = parseListOutput(

--- a/packages/mcp-server/src/tools/products.ts
+++ b/packages/mcp-server/src/tools/products.ts
@@ -10,10 +10,14 @@ import {
   BatchOperationSchema,
   BatchResponseSchema,
   DeleteResponseSchema,
+  ListDetailSchema,
+  ListFieldsSchema,
   PaginationInputSchema,
+  PRODUCT_SUMMARY_FIELDS,
   ProductSchema,
   parseListOutput,
   parseSingleOutput,
+  resolveListFields,
   textContent,
 } from "../types.js";
 
@@ -54,7 +58,7 @@ export function registerProductTools(server: McpServer, client: WooClient): void
     {
       title: "List products",
       description:
-        "Lists products from the WooCommerce catalog with pagination. Use this when you need to browse the catalog, build an inventory overview, or feed product data into a report. Returns product objects plus pagination metadata (total, totalPages, currentPage).",
+        "Lists products from the WooCommerce catalog with pagination. Default detail=summary uses a slim `_fields` projection (no HTML descriptions/images) to cut tokens and memory — use detail=full or woo_products_get when you need the complete product. Returns product objects plus pagination metadata.",
       inputSchema: {
         ...PaginationInputSchema.shape,
         status: z
@@ -75,12 +79,19 @@ export function registerProductTools(server: McpServer, client: WooClient): void
           .optional()
           .describe("Sort field"),
         order: z.enum(["asc", "desc"]).optional().describe("Sort direction"),
+        detail: ListDetailSchema,
+        fields: ListFieldsSchema,
       },
     },
     async (args) => {
       try {
         const page = args.page ?? 1;
         const per_page = args.per_page ?? 10;
+        const _fields = resolveListFields(
+          args.detail,
+          args.fields,
+          PRODUCT_SUMMARY_FIELDS,
+        );
         const res = await client.get<unknown[]>("products", {
           page,
           per_page,
@@ -90,6 +101,7 @@ export function registerProductTools(server: McpServer, client: WooClient): void
           stock_status: args.stock_status,
           orderby: args.orderby,
           order: args.order,
+          ...(_fields ? { _fields } : {}),
         });
         const meta = client.pagination(res, page, per_page);
         const out = parseListOutput(
@@ -211,23 +223,31 @@ export function registerProductTools(server: McpServer, client: WooClient): void
     {
       title: "Search products",
       description:
-        "Searches products by a free-text query matching name, SKU, and description fields. Use this when the user asks to find products by keyword rather than by ID or filters. Returns paginated matching products.",
+        "Searches products by a free-text query matching name, SKU, and description fields. Default detail=summary uses a slim `_fields` projection. Returns paginated matching products.",
       inputSchema: {
         query: z
           .string()
           .min(1)
           .describe("Search query string. Example: \"blue shirt\""),
         ...PaginationInputSchema.shape,
+        detail: ListDetailSchema,
+        fields: ListFieldsSchema,
       },
     },
     async (args) => {
       try {
         const page = args.page ?? 1;
         const per_page = args.per_page ?? 10;
+        const _fields = resolveListFields(
+          args.detail,
+          args.fields,
+          PRODUCT_SUMMARY_FIELDS,
+        );
         const res = await client.get<unknown[]>("products", {
           search: args.query,
           page,
           per_page,
+          ...(_fields ? { _fields } : {}),
         });
         const meta = client.pagination(res, page, per_page);
         const out = parseListOutput(

--- a/packages/mcp-server/src/tools/system-status.ts
+++ b/packages/mcp-server/src/tools/system-status.ts
@@ -1,5 +1,8 @@
 /**
  * System status tools — store health, environment, database, plugins.
+ * Default responses are slimmed: full system_status payloads are often 50–200KB+
+ * (plugins × meta, theme, pages) and dominate MCP context when agents only need
+ * version/security health checks.
  */
 
 import { z } from "zod";
@@ -20,6 +23,162 @@ const SystemStatusSchema = z
   })
   .passthrough();
 
+const STATUS_SECTIONS = [
+  "environment",
+  "database",
+  "active_plugins",
+  "theme",
+  "settings",
+  "security",
+  "pages",
+] as const;
+
+type StatusSection = (typeof STATUS_SECTIONS)[number];
+
+/** High-signal environment keys for summary mode (drops dozens of rarely needed flags). */
+const ENV_SUMMARY_KEYS = [
+  "home_url",
+  "site_url",
+  "version",
+  "wp_version",
+  "php_version",
+  "mysql_version",
+  "mysql_version_string",
+  "wc_version",
+  "server_info",
+  "memory_limit",
+  "max_execution_time",
+  "wp_memory_limit",
+  "wp_debug_mode",
+  "wp_cron",
+  "language",
+  "external_object_cache",
+] as const;
+
+function pickRecord(
+  source: Record<string, unknown> | undefined,
+  keys: readonly string[],
+): Record<string, unknown> | undefined {
+  if (!source) return undefined;
+  const out: Record<string, unknown> = {};
+  for (const k of keys) {
+    if (k in source) out[k] = source[k];
+  }
+  return Object.keys(out).length ? out : undefined;
+}
+
+function slimPlugin(plugin: unknown): unknown {
+  if (!plugin || typeof plugin !== "object") return plugin;
+  const p = plugin as Record<string, unknown>;
+  return {
+    plugin: p.plugin,
+    name: p.name,
+    version: p.version,
+    version_latest: p.version_latest,
+    author_name: p.author_name,
+    network_activated: p.network_activated,
+  };
+}
+
+function slimTheme(theme: Record<string, unknown> | undefined): Record<string, unknown> | undefined {
+  if (!theme) return undefined;
+  return {
+    name: theme.name,
+    version: theme.version,
+    version_latest: theme.version_latest,
+    author_url: theme.author_url,
+    is_child_theme: theme.is_child_theme,
+    has_woocommerce_support: theme.has_woocommerce_support,
+    has_woocommerce_file: theme.has_woocommerce_file,
+    has_outdated_templates: theme.has_outdated_templates,
+  };
+}
+
+/**
+ * Project system status for summary mode — keeps health-check signal,
+ * drops plugin meta blobs, full theme trees, and page lists unless requested.
+ */
+export function slimSystemStatus(
+  raw: Record<string, unknown>,
+  sections?: StatusSection[],
+): Record<string, unknown> {
+  const want = new Set<StatusSection>(
+    sections?.length ? sections : ["environment", "database", "active_plugins", "theme", "security"],
+  );
+  const out: Record<string, unknown> = {};
+
+  if (want.has("environment")) {
+    out.environment = pickRecord(
+      raw.environment as Record<string, unknown> | undefined,
+      ENV_SUMMARY_KEYS,
+    );
+  }
+  if (want.has("database")) {
+    const db = raw.database as Record<string, unknown> | undefined;
+    if (db) {
+      out.database = {
+        wc_database_version: db.wc_database_version,
+        database_prefix: db.database_prefix,
+        maxmind_geoip_database: db.maxmind_geoip_database,
+        database_size: db.database_size,
+        // Omit per-table rows — often the largest section on big stores.
+      };
+    }
+  }
+  if (want.has("active_plugins")) {
+    const plugins = raw.active_plugins;
+    out.active_plugins = Array.isArray(plugins) ? plugins.map(slimPlugin) : plugins;
+  }
+  if (want.has("theme")) {
+    out.theme = slimTheme(raw.theme as Record<string, unknown> | undefined);
+  }
+  if (want.has("settings")) {
+    const settings = raw.settings as Record<string, unknown> | undefined;
+    if (settings) {
+      out.settings = {
+        currency: settings.currency,
+        currency_symbol: settings.currency_symbol,
+        currency_position: settings.currency_position,
+        number_of_decimals: settings.number_of_decimals,
+        thousand_separator: settings.thousand_separator,
+        decimal_separator: settings.decimal_separator,
+        taxonomies: settings.taxonomies,
+        product_visibility_terms: undefined,
+        woocommerce_api_enabled: settings.woocommerce_api_enabled,
+        woocommerce_calc_taxes: settings.woocommerce_calc_taxes,
+        force_ssl: settings.force_ssl,
+      };
+      // Drop undefined keys from the slim object
+      for (const [k, v] of Object.entries(out.settings as Record<string, unknown>)) {
+        if (v === undefined) delete (out.settings as Record<string, unknown>)[k];
+      }
+    }
+  }
+  if (want.has("security")) {
+    out.security = raw.security;
+  }
+  if (want.has("pages")) {
+    // Pages array is large; summary only returns count + missing flags if present.
+    const pages = raw.pages;
+    if (Array.isArray(pages)) {
+      out.pages_summary = {
+        count: pages.length,
+        missing: pages
+          .filter((p) => {
+            const page = p as Record<string, unknown>;
+            return page.page_set === false || page.page_exists === false;
+          })
+          .map((p) => {
+            const page = p as Record<string, unknown>;
+            return { page_name: page.page_name, page_id: page.page_id };
+          }),
+      };
+    }
+  }
+
+  return out;
+}
+
 export function registerSystemStatusTools(
   server: McpServer,
   client: WooClient,
@@ -29,14 +188,49 @@ export function registerSystemStatusTools(
     {
       title: "Get system status",
       description:
-        "Fetches the full WooCommerce system status report including environment (PHP, WordPress, WC version), database, active plugins, theme, and security flags. Use this for store health checks, debugging plugin conflicts, or verifying the runtime before bulk operations.",
-      inputSchema: {},
+        "Fetches WooCommerce system status (environment, database, plugins, theme, security). Default detail=summary returns a slim health report suitable for agents; use detail=full for the complete payload (often 50–200KB+). Optionally pass `sections` to include only specific top-level keys.",
+      inputSchema: {
+        detail: z
+          .enum(["summary", "full"])
+          .default("summary")
+          .describe(
+            'Payload detail. "summary" (default) projects high-signal fields; "full" returns the raw WooCommerce report.',
+          ),
+        sections: z
+          .array(z.enum(STATUS_SECTIONS))
+          .optional()
+          .describe(
+            "Optional subset of top-level sections to include. Example: [\"environment\",\"security\"]",
+          ),
+      },
     },
-    async () => {
+    async (args) => {
       try {
         const res = await client.get("system_status");
-        const parsed = SystemStatusSchema.parse(res.data ?? {});
-        return textContent({ item: parsed });
+        const parsed = SystemStatusSchema.parse(res.data ?? {}) as Record<
+          string,
+          unknown
+        >;
+        const detail = args.detail ?? "summary";
+        const sections = args.sections as StatusSection[] | undefined;
+        let item: Record<string, unknown>;
+        if (detail === "full") {
+          if (sections?.length) {
+            item = {};
+            for (const s of sections) {
+              if (s in parsed) item[s] = parsed[s];
+            }
+          } else {
+            item = parsed;
+          }
+        } else {
+          item = slimSystemStatus(parsed, sections);
+        }
+        return textContent({
+          item,
+          detail,
+          ...(sections?.length ? { sections } : {}),
+        });
       } catch (err) {
         return toMcpToolError(err);
       }

--- a/packages/mcp-server/src/types.ts
+++ b/packages/mcp-server/src/types.ts
@@ -250,6 +250,52 @@ export const BatchOperationSchema = z.object({
     .describe("Array of resource IDs to delete"),
 });
 
+// ─── List field projection (memory + token savings) ───────────────────────────
+
+/**
+ * WooCommerce `_fields` projections for list endpoints.
+ * Summary omits HTML descriptions, images, meta, and address blobs that dominate
+ * MCP tool payloads when agents only need inventory/order overviews.
+ */
+export const PRODUCT_SUMMARY_FIELDS =
+  "id,name,slug,type,status,sku,price,regular_price,sale_price,stock_quantity,stock_status,manage_stock,categories,permalink";
+
+export const ORDER_SUMMARY_FIELDS =
+  "id,status,currency,total,customer_id,date_created,billing,shipping,line_items,number,payment_method";
+
+export const CUSTOMER_SUMMARY_FIELDS =
+  "id,email,first_name,last_name,username,role,date_created,orders_count,total_spent";
+
+/** Shared detail mode for high-volume list tools. Default is summary. */
+export const ListDetailSchema = z
+  .enum(["summary", "full"])
+  .default("summary")
+  .describe(
+    'Payload detail. "summary" (default) requests a slim `_fields` projection from WooCommerce to cut tokens/memory; "full" returns the complete entity. Override with `fields` for a custom comma-separated `_fields` list.',
+  );
+
+export const ListFieldsSchema = z
+  .string()
+  .optional()
+  .describe(
+    "Optional comma-separated WooCommerce `_fields` projection. When set, overrides the default summary field set. Example: id,name,price,stock_status",
+  );
+
+/**
+ * Resolve `_fields` for a list call.
+ * - detail=summary (default) → defaultFields unless `fields` overrides
+ * - detail=full → no projection unless `fields` is set
+ */
+export function resolveListFields(
+  detail: "summary" | "full" | undefined,
+  fields: string | undefined,
+  defaultFields: string,
+): string | undefined {
+  if (fields && fields.trim()) return fields.trim();
+  if (detail === "full") return undefined;
+  return defaultFields;
+}
+
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
 export function parseListOutput<T>(
@@ -291,19 +337,35 @@ export interface McpTextContentResult {
   _meta?: {
     "woo.usage": ToolPayloadUsage & { tool?: string };
   };
+  /** Index signature so results assign to MCP SDK CallToolResult. */
+  [key: string]: unknown;
 }
 
 /**
- * Serialize tool data as MCP text content.
+ * Compact JSON serialize — single-pass, no pretty-print whitespace.
+ * Pretty JSON (indent 2) inflates MCP tool payloads ~25–40% for nested WC objects,
+ * which multiplies into model input tokens on every tool result.
+ */
+export function compactJson(data: unknown): string {
+  if (typeof data === "string") return data;
+  return JSON.stringify(data);
+}
+
+/**
+ * Serialize tool data as MCP text content (compact JSON).
  * Always attaches token-usage estimates (payload size) unless includeUsage=false.
+ *
+ * Single-pass path: when attaching usage we stringify once for the estimate,
+ * then build the final body and stringify once more (unavoidable if usage is
+ * embedded). No pretty-print intermediate strings are retained.
  */
 export function textContent(
   data: unknown,
   options: TextContentOptions = {},
 ): McpTextContentResult {
   const includeUsage = options.includeUsage !== false;
-  let body: unknown = data;
   let usage: ToolPayloadUsage | undefined;
+  let text: string;
 
   if (
     includeUsage &&
@@ -313,13 +375,15 @@ export function textContent(
   ) {
     // Estimate from business payload only (before attaching usage) so the
     // usage object does not inflate its own estimate.
-    const baseText = JSON.stringify(data);
+    const baseText = compactJson(data);
     usage = recordToolUsage(baseText, { tool: options.tool });
-    body = { ...(data as Record<string, unknown>), usage };
+    text = compactJson({
+      ...(data as Record<string, unknown>),
+      usage,
+    });
+  } else {
+    text = compactJson(data);
   }
-
-  const text =
-    typeof body === "string" ? body : JSON.stringify(body, null, 2);
 
   if (!includeUsage) {
     return { content: [{ type: "text", text }] };

--- a/packages/mcp-server/src/usage.ts
+++ b/packages/mcp-server/src/usage.ts
@@ -73,7 +73,12 @@ export interface ModelUsageReport {
   totals: ModelUsageTotals;
 }
 
-const MAX_RECENT = 50;
+/** Ring-buffer size for recent tool payloads (keeps session memory bounded). */
+const MAX_RECENT = 20;
+/** Cap stored host model reports (each may hold many rounds). */
+const MAX_MODEL_REPORTS = 10;
+/** Cap rounds retained inside a single ModelUsageTracker instance. */
+const MAX_MODEL_ROUNDS = 40;
 
 /** Process-wide session counters for this MCP server instance. */
 class UsageSession {
@@ -109,8 +114,17 @@ class UsageSession {
   }
 
   recordModelReport(report: ModelUsageReport): void {
-    this.modelReports.push(report);
-    if (this.modelReports.length > 20) this.modelReports.shift();
+    // Store a shallow copy with capped rounds so long agent loops cannot
+    // retain unbounded history in the MCP process heap.
+    const capped: ModelUsageReport = {
+      ...report,
+      rounds:
+        report.rounds.length > MAX_MODEL_ROUNDS
+          ? report.rounds.slice(-MAX_MODEL_ROUNDS)
+          : report.rounds,
+    };
+    this.modelReports.push(capped);
+    if (this.modelReports.length > MAX_MODEL_REPORTS) this.modelReports.shift();
   }
 
   snapshot(): {
@@ -233,7 +247,10 @@ function mergeModelTotals(into: ModelUsageTotals, add: ModelUsageTotals): void {
  */
 export class ModelUsageTracker {
   private rounds: ModelRoundUsage[] = [];
+  /** Totals kept separately so ring-buffering rounds does not lose aggregate counts. */
+  private running = emptyModelTotals();
   private readonly provider: string;
+  private finalized = false;
 
   constructor(provider = "anthropic") {
     this.provider = provider;
@@ -242,6 +259,7 @@ export class ModelUsageTracker {
   /**
    * Record one model API response.
    * Accepts Anthropic (`input_tokens`/`output_tokens`) shapes.
+   * Rounds are ring-buffered (MAX_MODEL_ROUNDS) while totals stay exact.
    */
   addRound(
     usage: {
@@ -260,7 +278,7 @@ export class ModelUsageTracker {
     const output =
       usage?.output_tokens ?? usage?.completion_tokens ?? 0;
     const round: ModelRoundUsage = {
-      round: this.rounds.length + 1,
+      round: this.running.rounds + 1,
       model: options.model,
       input_tokens: Number(input) || 0,
       output_tokens: Number(output) || 0,
@@ -269,38 +287,55 @@ export class ModelUsageTracker {
       stop_reason: options.stop_reason ?? null,
     };
     this.rounds.push(round);
+    if (this.rounds.length > MAX_MODEL_ROUNDS) this.rounds.shift();
+
+    this.running.rounds += 1;
+    this.running.input_tokens += round.input_tokens;
+    this.running.output_tokens += round.output_tokens;
+    this.running.cache_creation_input_tokens +=
+      round.cache_creation_input_tokens ?? 0;
+    this.running.cache_read_input_tokens += round.cache_read_input_tokens ?? 0;
+    this.running.total_tokens =
+      this.running.input_tokens + this.running.output_tokens;
+    const model = round.model || "unknown";
+    const cur = this.running.by_model[model] ?? {
+      rounds: 0,
+      input_tokens: 0,
+      output_tokens: 0,
+      total_tokens: 0,
+    };
+    cur.rounds += 1;
+    cur.input_tokens += round.input_tokens;
+    cur.output_tokens += round.output_tokens;
+    cur.total_tokens += round.input_tokens + round.output_tokens;
+    this.running.by_model[model] = cur;
+
     return round;
   }
 
   finalize(): ModelUsageReport {
-    const totals = emptyModelTotals();
-    totals.rounds = this.rounds.length;
-    for (const r of this.rounds) {
-      totals.input_tokens += r.input_tokens;
-      totals.output_tokens += r.output_tokens;
-      totals.cache_creation_input_tokens += r.cache_creation_input_tokens ?? 0;
-      totals.cache_read_input_tokens += r.cache_read_input_tokens ?? 0;
-      const model = r.model || "unknown";
-      const cur = totals.by_model[model] ?? {
-        rounds: 0,
-        input_tokens: 0,
-        output_tokens: 0,
-        total_tokens: 0,
-      };
-      cur.rounds += 1;
-      cur.input_tokens += r.input_tokens;
-      cur.output_tokens += r.output_tokens;
-      cur.total_tokens += r.input_tokens + r.output_tokens;
-      totals.by_model[model] = cur;
+    // Idempotent: hosts sometimes call finalize more than once; only record once.
+    const byModel: ModelUsageTotals["by_model"] = {};
+    for (const [model, stats] of Object.entries(this.running.by_model)) {
+      byModel[model] = { ...stats };
     }
-    totals.total_tokens = totals.input_tokens + totals.output_tokens;
-
     const report: ModelUsageReport = {
       provider: this.provider,
       rounds: [...this.rounds],
-      totals,
+      totals: {
+        rounds: this.running.rounds,
+        input_tokens: this.running.input_tokens,
+        output_tokens: this.running.output_tokens,
+        cache_creation_input_tokens: this.running.cache_creation_input_tokens,
+        cache_read_input_tokens: this.running.cache_read_input_tokens,
+        total_tokens: this.running.total_tokens,
+        by_model: byModel,
+      },
     };
-    usageSession.recordModelReport(report);
+    if (!this.finalized) {
+      this.finalized = true;
+      usageSession.recordModelReport(report);
+    }
     return report;
   }
 }

--- a/packages/mcp-server/tests/client.test.ts
+++ b/packages/mcp-server/tests/client.test.ts
@@ -35,8 +35,8 @@ describe("ConcurrencyThrottler", () => {
 });
 
 describe("RateLimiter", () => {
-  it("schedules functions sequentially respecting interval", async () => {
-    const limiter = new RateLimiter(50); // 20ms interval
+  it("allows a burst up to the bucket capacity", async () => {
+    const limiter = new RateLimiter(50); // capacity 50 tokens
     const times: number[] = [];
     await Promise.all(
       [1, 2, 3].map(() =>
@@ -46,8 +46,22 @@ describe("RateLimiter", () => {
       ),
     );
     expect(times).toHaveLength(3);
-    // At least some spacing between starts
-    expect(times[2]! - times[0]!).toBeGreaterThanOrEqual(15);
+    // Burst: three tokens available immediately (no forced spacing chain)
+    expect(times[2]! - times[0]!).toBeLessThan(30);
+  });
+
+  it("throttles sustained traffic above the rate", async () => {
+    // 5 RPS, capacity 5 — 10 jobs require ~1s of refill after the first burst
+    const limiter = new RateLimiter(5, 5);
+    const start = Date.now();
+    await Promise.all(
+      Array.from({ length: 10 }, () =>
+        limiter.schedule(async () => undefined),
+      ),
+    );
+    const elapsed = Date.now() - start;
+    // 5 immediate + 5 refilled at 5/s ⇒ ≥ ~800ms under load (allow jitter)
+    expect(elapsed).toBeGreaterThanOrEqual(700);
   });
 });
 

--- a/packages/mcp-server/tests/errors.test.ts
+++ b/packages/mcp-server/tests/errors.test.ts
@@ -59,6 +59,22 @@ describe("toMcpToolError", () => {
     expect(payload.content[0].type).toBe("text");
     expect(payload.content[0].text).toMatch(/fail/);
   });
+
+  it("truncates oversized error details", () => {
+    const err = Object.assign(new Error("Request failed"), {
+      response: {
+        status: 500,
+        data: {
+          code: "internal_server_error",
+          message: "Boom",
+          data: { html: "x".repeat(5000) },
+        },
+      },
+    });
+    const payload = toMcpToolError(err);
+    expect(payload.content[0].text.length).toBeLessThan(1200);
+    expect(payload.content[0].text).toMatch(/truncated/);
+  });
 });
 
 describe("withToolErrorHandling", () => {

--- a/packages/mcp-server/tests/system-status-slim.test.ts
+++ b/packages/mcp-server/tests/system-status-slim.test.ts
@@ -1,0 +1,122 @@
+import { slimSystemStatus } from "../src/tools/system-status.js";
+
+describe("slimSystemStatus", () => {
+  const fat: Record<string, unknown> = {
+    environment: {
+      home_url: "http://localhost",
+      version: "9.0.0",
+      wp_version: "6.5",
+      php_version: "8.2",
+      rarely_needed_flag_a: true,
+      rarely_needed_flag_b: false,
+      long_path_info: "/var/www/html/wp-content/plugins/woocommerce",
+    },
+    database: {
+      wc_database_version: "9.0.0",
+      database_prefix: "wp_",
+      database_tables: {
+        wp_posts: { data: "10MB", index: "2MB" },
+        wp_postmeta: { data: "50MB", index: "20MB" },
+      },
+    },
+    active_plugins: [
+      {
+        plugin: "woocommerce/woocommerce.php",
+        name: "WooCommerce",
+        version: "9.0.0",
+        version_latest: "9.0.0",
+        author_name: "Automattic",
+        network_activated: false,
+        author_url: "https://woocommerce.com",
+        plugin_uri: "https://woocommerce.com",
+      },
+    ],
+    theme: {
+      name: "Storefront",
+      version: "4.5",
+      version_latest: "4.5",
+      author_url: "https://woocommerce.com",
+      is_child_theme: false,
+      has_woocommerce_support: true,
+      has_woocommerce_file: true,
+      has_outdated_templates: false,
+      file_headers: { huge: "blob" },
+    },
+    security: { secure_connection: true, hide_errors: true },
+    pages: [
+      { page_name: "Shop", page_id: 1, page_set: true, page_exists: true },
+      { page_name: "Cart", page_id: 0, page_set: false, page_exists: false },
+    ],
+    settings: {
+      currency: "USD",
+      currency_symbol: "$",
+      product_visibility_terms: { huge: true },
+    },
+  };
+
+  it("drops low-signal environment keys and table rows", () => {
+    const slim = slimSystemStatus(fat);
+    const env = slim.environment as Record<string, unknown>;
+    expect(env.version).toBe("9.0.0");
+    expect(env.rarely_needed_flag_a).toBeUndefined();
+    expect(env.long_path_info).toBeUndefined();
+
+    const db = slim.database as Record<string, unknown>;
+    expect(db.wc_database_version).toBe("9.0.0");
+    expect(db.database_tables).toBeUndefined();
+  });
+
+  it("slims plugins; pages only when requested", () => {
+    const slim = slimSystemStatus(fat);
+    const plugins = slim.active_plugins as Array<Record<string, unknown>>;
+    expect(plugins[0]).toMatchObject({ name: "WooCommerce", version: "9.0.0" });
+    expect(plugins[0].plugin_uri).toBeUndefined();
+    // Default summary omits pages to keep the health report small.
+    expect(slim.pages).toBeUndefined();
+    expect(slim.pages_summary).toBeUndefined();
+
+    const withPages = slimSystemStatus(fat, ["pages"]);
+    expect(withPages.pages_summary).toMatchObject({
+      count: 2,
+      missing: [{ page_name: "Cart", page_id: 0 }],
+    });
+  });
+
+  it("is substantially smaller than the raw payload", () => {
+    // Simulate a realistic fat report with many plugins
+    const manyPlugins = {
+      ...fat,
+      active_plugins: Array.from({ length: 40 }, (_, i) => ({
+        plugin: `plugin-${i}/plugin.php`,
+        name: `Plugin ${i}`,
+        version: "1.0.0",
+        version_latest: "1.0.0",
+        author_name: "Author",
+        network_activated: false,
+        author_url: "https://example.com/" + "x".repeat(80),
+        plugin_uri: "https://example.com/plugin/" + "y".repeat(80),
+        description: "d".repeat(200),
+      })),
+      database: {
+        ...((fat.database as object) ?? {}),
+        database_tables: Object.fromEntries(
+          Array.from({ length: 80 }, (_, i) => [
+            `wp_table_${i}`,
+            { data: "1MB", index: "0.5MB", engine: "InnoDB" },
+          ]),
+        ),
+      },
+    };
+    const rawSize = JSON.stringify(manyPlugins).length;
+    const slimSize = JSON.stringify(slimSystemStatus(manyPlugins)).length;
+    expect(slimSize).toBeLessThan(rawSize * 0.35);
+  });
+
+  it("respects sections filter", () => {
+    const slim = slimSystemStatus(fat, ["environment", "security"]);
+    expect(slim.environment).toBeDefined();
+    expect(slim.security).toBeDefined();
+    expect(slim.active_plugins).toBeUndefined();
+    expect(slim.database).toBeUndefined();
+  });
+});

--- a/packages/mcp-server/tests/tools/products.test.ts
+++ b/packages/mcp-server/tests/tools/products.test.ts
@@ -39,6 +39,40 @@ describe("product tools", () => {
     expect((data as { items: unknown[] }).items).toHaveLength(2);
   });
 
+  it("woo_products_list default summary sends _fields projection", async () => {
+    nock(TEST_BASE)
+      .get(apiPath("/products"))
+      .query((q) => typeof q._fields === "string" && String(q._fields).includes("id"))
+      .reply(200, [{ id: 1, name: "Slim", price: "9.99" }], {
+        "x-wp-total": "1",
+        "x-wp-totalpages": "1",
+      });
+
+    const { data, isError } = await callTool(ctx.client, "woo_products_list", {
+      page: 1,
+      per_page: 5,
+    });
+    expect(isError).toBe(false);
+    expect((data as { items: unknown[] }).items[0]).toMatchObject({ id: 1 });
+  });
+
+  it("woo_products_list detail=full omits _fields", async () => {
+    nock(TEST_BASE)
+      .get(apiPath("/products"))
+      .query((q) => q._fields === undefined)
+      .reply(200, products, {
+        "x-wp-total": "2",
+        "x-wp-totalpages": "1",
+      });
+
+    const { isError } = await callTool(ctx.client, "woo_products_list", {
+      page: 1,
+      per_page: 10,
+      detail: "full",
+    });
+    expect(isError).toBe(false);
+  });
+
   it("woo_products_get returns a single product", async () => {
     nock(TEST_BASE)
       .get(apiPath("/products/1"))

--- a/packages/mcp-server/tests/types.test.ts
+++ b/packages/mcp-server/tests/types.test.ts
@@ -3,6 +3,9 @@ import {
   parseSingleOutput,
   ProductSchema,
   BatchOperationSchema,
+  compactJson,
+  resolveListFields,
+  PRODUCT_SUMMARY_FIELDS,
   textContent,
 } from "../src/types.js";
 
@@ -34,10 +37,38 @@ describe("types helpers", () => {
     expect(parsed.delete).toEqual([2, 3]);
   });
 
-  it("textContent serializes objects and includes usage", () => {
+  it("textContent serializes compact JSON and includes usage", () => {
     const c = textContent({ ok: true });
-    expect(c.content[0].text).toMatch(/"ok": true/);
+    // Compact JSON: no pretty-print spaces after colons/newlines
+    expect(c.content[0].text).toMatch(/"ok":true/);
+    expect(c.content[0].text).not.toMatch(/\n/);
     expect(c.content[0].text).toMatch(/"usage"/);
     expect(c._meta?.["woo.usage"].estimated_response_tokens).toBeGreaterThan(0);
+  });
+
+  it("compactJson is smaller than pretty JSON", () => {
+    const payload = {
+      items: Array.from({ length: 20 }, (_, i) => ({
+        id: i,
+        name: `Product ${i}`,
+        description: "<p>Long HTML description that agents rarely need in lists</p>",
+      })),
+    };
+    const compact = compactJson(payload);
+    const pretty = JSON.stringify(payload, null, 2);
+    expect(compact.length).toBeLessThan(pretty.length);
+    expect((pretty.length - compact.length) / pretty.length).toBeGreaterThan(0.15);
+  });
+
+  it("resolveListFields defaults to summary projection", () => {
+    expect(resolveListFields(undefined, undefined, PRODUCT_SUMMARY_FIELDS)).toBe(
+      PRODUCT_SUMMARY_FIELDS,
+    );
+    expect(resolveListFields("summary", undefined, PRODUCT_SUMMARY_FIELDS)).toBe(
+      PRODUCT_SUMMARY_FIELDS,
+    );
+    expect(resolveListFields("full", undefined, PRODUCT_SUMMARY_FIELDS)).toBeUndefined();
+    expect(resolveListFields("full", "id,name", PRODUCT_SUMMARY_FIELDS)).toBe("id,name");
+    expect(resolveListFields("summary", "id,sku", PRODUCT_SUMMARY_FIELDS)).toBe("id,sku");
   });
 });


### PR DESCRIPTION
## Summary
- Compact MCP tool JSON (no pretty-print) and default `detail=summary` `_fields` projection on product/order/customer lists (and search).
- Slim `woo_system_status_get` by default; token-bucket rate limiter with single throttle point (`maxConcurrentRequests: 0` on the REST client).
- Cap error detail size and usage session ring buffers; add `bench:perf` impact proof (~90% smaller list tool tokens).

## Motivation
Agent loops pay for every byte of tool results as model input tokens. Multi-agent analysis ranked compact serialization, field projection, system-status slimming, rate-limit double-throttle removal, and error/session caps as highest ROI.

## Impact proof (`pnpm --filter woo-mcp-server bench:perf`)
| Case | Saved |
|------|-------|
| Compact JSON (20 products) | ~29% |
| List `_fields` summary | ~87% |
| System status summary | ~69% |
| Error detail truncation | ~94% |
| RateLimiter burst (15 @ 20 RPS) | ~99% latency |
| Combined list payload | **~90%** (~17.6k → ~1.7k estimated tokens) |

## Test plan
- [x] `pnpm --filter woo-mcp-server build`
- [x] `pnpm --filter woo-mcp-server test` (77 passed, coverage threshold met)
- [x] `pnpm --filter woo-mcp-server bench:perf` (all thresholds met)
- [ ] Optional: live store list with default summary vs `detail=full`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## User-facing impact

### woo-mcp-server
- MCP list/search tools now default to slimmer responses (`detail=summary`) with `_fields` projections, reducing payload size, token usage, and latency.
- `woo_system_status_get` now returns a compact summary by default, with optional full/sectioned output.
- MCP tool output is serialized compactly, error details are truncated, and usage/session buffers are capped to reduce memory growth.
- Rate limiting now uses a token-bucket model with a single throttle point on the REST client, improving burst handling and avoiding double-throttling.
- A new `bench:perf` benchmark and additional tests were added to validate these changes.

### woocommerce-rest-ts-api
- No direct library-facing API changes are shown in this PR summary, but the MCP server now relies on the REST client being configured with `maxConcurrentRequests: 0` so the MCP layer is the sole throttle point.

## Breaking changes
- List/search tool defaults are slimmer than before, so consumers expecting full payloads must now opt into `detail=full` or request explicit fields.
- `woo_system_status_get` no longer returns the full status payload by default.
- Public exports were expanded/adjusted in `packages/mcp-server/src/server.ts`, which may affect consumers importing internals from the MCP package.

## Security / reliability
- Error payload truncation and bounded usage/session buffers reduce the risk of model-context bloat and unbounded memory growth.

## Release risk
- Medium: behavior changes are concentrated in core MCP tools, serialization, and rate limiting, but are covered by new benchmarks and tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->